### PR TITLE
Scroll Y is now linear + some variable renames

### DIFF
--- a/CONFIG/mmc3-album-huge.cfg
+++ b/CONFIG/mmc3-album-huge.cfg
@@ -288,14 +288,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/mmc3-album.cfg
+++ b/CONFIG/mmc3-album.cfg
@@ -96,14 +96,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+	COLLMAP:  load = WRAM,	 type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/mmc3-huge-vs.cfg
+++ b/CONFIG/mmc3-huge-vs.cfg
@@ -288,14 +288,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/mmc3-huge.cfg
+++ b/CONFIG/mmc3-huge.cfg
@@ -288,14 +288,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/mmc3.cfg
+++ b/CONFIG/mmc3.cfg
@@ -97,14 +97,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/nsf.cfg
+++ b/CONFIG/nsf.cfg
@@ -123,14 +123,7 @@ MEMORY {
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
 	NSF_HEADER:   load = NSF_HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/CONFIG/vs-sys.cfg
+++ b/CONFIG/vs-sys.cfg
@@ -96,14 +96,7 @@ MEMORY {
 
 SEGMENTS {
     HEADER:   load = HEADER, type = ro, define = yes;
-	COLLMAP0: load = WRAM,	 type = bss, start = $6000, define = yes;
-	WRAM_SL0: load = WRAM,	 type = bss, start = $60F0, define = yes, optional = yes;
-	COLLMAP1: load = WRAM,	 type = bss, start = $6100, define = yes;
-	WRAM_SL1: load = WRAM,	 type = bss, start = $61F0, define = yes, optional = yes;
-    COLLMAP2: load = WRAM,	 type = bss, start = $6200, define = yes;
-	WRAM_SL2: load = WRAM,	 type = bss, start = $62F0, define = yes, optional = yes;
-	COLLMAP3: load = WRAM,	 type = bss, start = $6300, define = yes;
-	WRAM_SL3: load = WRAM,	 type = bss, start = $63F0, define = yes, optional = yes;
+    COLLMAP:  load = WRAM,   type = bss, start = $6000, define = yes;
     SRAM:     load = WRAM,   type = rw,  align = $0100, define = yes;
     IRQ_T:    load = WRAM,   type = bss, start = $7FC0, define = yes;
     # Banks for mmc3 are split into two groups: 

--- a/LEVELS/export_levels.py
+++ b/LEVELS/export_levels.py
@@ -226,7 +226,7 @@ def export_bg(folder: pathlib.PurePath, levels: Iterable[dict], include_path : p
 			metadata.get('songID', 0),
 			f"({metadata.get('startingSpeed', 0)} << 4) | {metadata.get('startingGameMode', 0)}",
 			f"(${metadata.get('spawnYPositionHi', 0xB0):02X})",
-			f"(${metadata.get('scrollYPositionLow', 0xEF):02X})",
+			f"(${(metadata.get('scrollYPosition', 0x02CF) & 0xFF):02X})",
 			" | ".join([
 				f"({int(bool(metadata.get(name)))} << {idx})"
 				for idx, name in enumerate(['forcePlatformer', 'parallaxDisable'])

--- a/LEVELS/include/lvlset_A/all_level_data.s
+++ b/LEVELS/include/lvlset_A/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_extraordinary_excitement ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________________________ Spike Set, Block Set
@@ -36,7 +36,7 @@
 		.byte song_rainbow_tylenol ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;__________________ Spike Set, Block Set
@@ -49,7 +49,7 @@
 	.align 8192
 
 
-; Data bank 02, total bank size: 8127 bytes
+; Data bank 02, total bank size: 7916 bytes
 	.export level_data_dash
 	level_data_dash:
 	; Header
@@ -59,7 +59,7 @@
 		.byte song_dash ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -69,12 +69,10 @@
 	; Level data
 		.incbin "EXPORTS/level/dash.lz.bin" ; Size: 7903
 
-	sprite_data_thecellar:	; Size: 211
-		.incbin "EXPORTS/sprite/thecellar.bin"
 	.align 8192
 
 
-; Data bank 03, total bank size: 8118 bytes
+; Data bank 03, total bank size: 7777 bytes
 	.export level_data_fingerdash
 	level_data_fingerdash:
 	; Header
@@ -84,7 +82,7 @@
 		.byte song_fingerdash ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -94,12 +92,10 @@
 	; Level data
 		.incbin "EXPORTS/level/fingerdash.lz.bin" ; Size: 7764
 
-	sprite_data_thesewers:	; Size: 341
-		.incbin "EXPORTS/sprite/thesewers.bin"
 	.align 8192
 
 
-; Data bank 04, total bank size: 8057 bytes
+; Data bank 04, total bank size: 7776 bytes
 	.export level_data_groundtospace
 	level_data_groundtospace:
 	; Header
@@ -109,7 +105,7 @@
 		.byte song_ground_to_space ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -119,8 +115,6 @@
 	; Level data
 		.incbin "EXPORTS/level/groundtospace.lz.bin" ; Size: 7763
 
-	sprite_data_thesecrethollow:	; Size: 281
-		.incbin "EXPORTS/sprite/thesecrethollow.bin"
 	.align 8192
 
 
@@ -134,7 +128,7 @@
 		.byte song_hexagon_force ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -147,7 +141,7 @@
 	.align 8192
 
 
-; Data bank 06, total bank size: 8175 bytes
+; Data bank 06, total bank size: 7952 bytes
 	.export level_data_deadlocked
 	level_data_deadlocked:
 	; Header
@@ -157,7 +151,7 @@
 		.byte song_deadlocked ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -167,29 +161,29 @@
 	; Level data
 		.incbin "EXPORTS/level/deadlocked.lz.bin" ; Size: 6406
 
-	.export level_data_polargeist
-	level_data_polargeist:
+	.export level_data_dryout
+	level_data_dryout:
 	; Header
-		.byte <sprite_data_polargeist ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_polargeist) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_polargeist >> 13) ;_________ Sprite data bank
-		.byte song_polargeist ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
-		.byte $2A ;_____________________________________ Starting background color
-		.byte $1A ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
+		.byte <sprite_data_dryout ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_dryout) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_dryout >> 13) ;_________ Sprite data bank
+		.byte song_dry_out ;________________________ Song ID
+		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
+		.byte $16 ;_________________________________ Starting background color
+		.byte $16 ;_________________________________ Starting ground color
+		.byte 27 ;__________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/polargeist.lz.bin" ; Size: 1743
+		.incbin "EXPORTS/level/dryout.lz.bin" ; Size: 1520
 
 	.align 8192
 
 
-; Data bank 07, total bank size: 8117 bytes
+; Data bank 07, total bank size: 8027 bytes
 	.export level_data_geometricaldominator
 	level_data_geometricaldominator:
 	; Header
@@ -199,7 +193,7 @@
 		.byte song_geometrical_dominator ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________________ Spike Set, Block Set
@@ -209,39 +203,14 @@
 	; Level data
 		.incbin "EXPORTS/level/geometricaldominator.lz.bin" ; Size: 6383
 
-	sprite_data_thelightningroad:	; Size: 1721
-		.incbin "EXPORTS/sprite/thelightningroad.bin"
+	sprite_data_hexagonforce:	; Size: 1631
+		.incbin "EXPORTS/sprite/hexagonforce.bin"
 	.align 8192
 
 
-; Data bank 08, total bank size: 8192 bytes
+; Data bank 08, total bank size: 8086 bytes
 	sprite_data_rainbowtylenol:	; Size: 6171
 		.incbin "EXPORTS/sprite/rainbowtylenol.bin"
-	sprite_data_bloodbathbutno:	; Size: 2021
-		.incbin "EXPORTS/sprite/bloodbathbutno.bin"
-	.align 8192
-
-
-; Data bank 09, total bank size: 8058 bytes
-	.export level_data_lostinthewoods
-	level_data_lostinthewoods:
-	; Header
-		.byte <sprite_data_lostinthewoods ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_lostinthewoods) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_lostinthewoods >> 13) ;_________ Sprite data bank
-		.byte song_haunted_woods ;__________________________ Song ID
-		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $0F ;_________________________________________ Starting background color
-		.byte $0F ;_________________________________________ Starting ground color
-		.byte 47 ;__________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/lostinthewoods.lz.bin" ; Size: 6130
-
 	.export level_data_jumper
 	level_data_jumper:
 	; Header
@@ -251,7 +220,7 @@
 		.byte song_jumper ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSC ;__________ Spike Set, Block Set
@@ -264,7 +233,32 @@
 	.align 8192
 
 
-; Data bank 0A, total bank size: 8191 bytes
+; Data bank 09, total bank size: 8164 bytes
+	.export level_data_lostinthewoods
+	level_data_lostinthewoods:
+	; Header
+		.byte <sprite_data_lostinthewoods ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_lostinthewoods) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_lostinthewoods >> 13) ;_________ Sprite data bank
+		.byte song_haunted_woods ;__________________________ Song ID
+		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $0F ;_________________________________________ Starting background color
+		.byte $0F ;_________________________________________ Starting ground color
+		.byte 47 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/lostinthewoods.lz.bin" ; Size: 6130
+
+	sprite_data_bloodbathbutno:	; Size: 2021
+		.incbin "EXPORTS/sprite/bloodbathbutno.bin"
+	.align 8192
+
+
+; Data bank 0A, total bank size: 8167 bytes
 	.export level_data_sunshine
 	level_data_sunshine:
 	; Header
@@ -274,7 +268,7 @@
 		.byte song_just_right ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -284,29 +278,29 @@
 	; Level data
 		.incbin "EXPORTS/level/sunshine.lz.bin" ; Size: 6125
 
-	.export level_data_cantletgo
-	level_data_cantletgo:
+	.export level_data_baseafterbase
+	level_data_baseafterbase:
 	; Header
-		.byte <sprite_data_cantletgo ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_cantletgo) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_cantletgo >> 13) ;_________ Sprite data bank
-		.byte song_cant_let_go ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
-		.byte $14 ;____________________________________ Starting background color
-		.byte $04 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
+		.byte <sprite_data_baseafterbase ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_baseafterbase) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_baseafterbase >> 13) ;_________ Sprite data bank
+		.byte song_base_after_base ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
+		.byte $11 ;________________________________________ Starting background color
+		.byte $11 ;________________________________________ Starting ground color
+		.byte 27 ;_________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/cantletgo.lz.bin" ; Size: 2040
+		.incbin "EXPORTS/level/baseafterbase.lz.bin" ; Size: 2016
 
 	.align 8192
 
 
-; Data bank 0B, total bank size: 8188 bytes
+; Data bank 0B, total bank size: 8185 bytes
 	.export level_data_toe2
 	level_data_toe2:
 	; Header
@@ -316,7 +310,7 @@
 		.byte song_toe_2 ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -325,6 +319,31 @@
 		.byte 27 ;________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/toe2.lz.bin" ; Size: 6041
+
+	sprite_data_blastprocessing:	; Size: 2131
+		.incbin "EXPORTS/sprite/blastprocessing.bin"
+	.align 8192
+
+
+; Data bank 0C, total bank size: 8170 bytes
+	.export level_data_bloodbathbutno
+	level_data_bloodbathbutno:
+	; Header
+		.byte <sprite_data_bloodbathbutno ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_bloodbathbutno) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_bloodbathbutno >> 13) ;_________ Sprite data bank
+		.byte song_atthespeedoflight2 ;_____________________ Song ID
+		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $0F ;_________________________________________ Starting background color
+		.byte $0F ;_________________________________________ Starting ground color
+		.byte 40 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/bloodbathbutno.lz.bin" ; Size: 6023
 
 	.export level_data_thesecrethollow
 	level_data_thesecrethollow:
@@ -335,7 +354,7 @@
 		.byte song_casual_game_music_09 ;____________________ Song ID
 		.byte (0 << 4) | 4 ;_________________________________ Starting game mode and speed
 		.byte ($40) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (1 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -348,40 +367,15 @@
 	.align 8192
 
 
-; Data bank 0C, total bank size: 8167 bytes
-	.export level_data_bloodbathbutno
-	level_data_bloodbathbutno:
-	; Header
-		.byte <sprite_data_bloodbathbutno ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_bloodbathbutno) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_bloodbathbutno >> 13) ;_________ Sprite data bank
-		.byte song_atthespeedoflight2 ;_____________________ Song ID
-		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $0F ;_________________________________________ Starting background color
-		.byte $0F ;_________________________________________ Starting ground color
-		.byte 40 ;__________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/bloodbathbutno.lz.bin" ; Size: 6023
-
-	sprite_data_blastprocessing:	; Size: 2131
-		.incbin "EXPORTS/sprite/blastprocessing.bin"
-	.align 8192
-
-
-; Data bank 0D, total bank size: 8102 bytes
+; Data bank 0D, total bank size: 8027 bytes
 	sprite_data_extraordinaryexcitement:	; Size: 5781
 		.incbin "EXPORTS/sprite/extraordinaryexcitement.bin"
-	sprite_data_timemachine:	; Size: 2321
-		.incbin "EXPORTS/sprite/timemachine.bin"
+	sprite_data_nightmare:	; Size: 2246
+		.incbin "EXPORTS/sprite/nightmare.bin"
 	.align 8192
 
 
-; Data bank 0E, total bank size: 8170 bytes
+; Data bank 0E, total bank size: 8020 bytes
 	.export level_data_electrodynamix
 	level_data_electrodynamix:
 	; Header
@@ -391,7 +385,7 @@
 		.byte song_electrodynamix ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -401,12 +395,12 @@
 	; Level data
 		.incbin "EXPORTS/level/electrodynamix.lz.bin" ; Size: 5726
 
-	sprite_data_geometricaldominator:	; Size: 2431
-		.incbin "EXPORTS/sprite/geometricaldominator.bin"
+	sprite_data_theoryofeverything:	; Size: 2281
+		.incbin "EXPORTS/sprite/theoryofeverything.bin"
 	.align 8192
 
 
-; Data bank 0F, total bank size: 8175 bytes
+; Data bank 0F, total bank size: 8120 bytes
 	.export level_data_clubstep
 	level_data_clubstep:
 	; Header
@@ -416,7 +410,7 @@
 		.byte song_clubstep ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -426,12 +420,12 @@
 	; Level data
 		.incbin "EXPORTS/level/clubstep.lz.bin" ; Size: 5676
 
-	sprite_data_dash:	; Size: 2486
-		.incbin "EXPORTS/sprite/dash.bin"
+	sprite_data_geometricaldominator:	; Size: 2431
+		.incbin "EXPORTS/sprite/geometricaldominator.bin"
 	.align 8192
 
 
-; Data bank 10, total bank size: 8135 bytes
+; Data bank 10, total bank size: 8054 bytes
 	.export level_data_revolution
 	level_data_revolution:
 	; Header
@@ -441,7 +435,7 @@
 		.byte song_infernoplex ;________________________ Song ID
 		.byte (3 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -451,29 +445,12 @@
 	; Level data
 		.incbin "EXPORTS/level/revolution.lz.bin" ; Size: 5425
 
-	.export level_data_retray
-	level_data_retray:
-	; Header
-		.byte <sprite_data_retray ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_retray) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_retray >> 13) ;_________ Sprite data bank
-		.byte song_retray ;_________________________ Song ID
-		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
-		.byte $0F ;_________________________________ Starting background color
-		.byte $0F ;_________________________________ Starting ground color
-		.byte 27 ;__________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/retray.lz.bin" ; Size: 2684
-
+	sprite_data_xstep:	; Size: 2616
+		.incbin "EXPORTS/sprite/xstep.bin"
 	.align 8192
 
 
-; Data bank 11, total bank size: 8115 bytes
+; Data bank 11, total bank size: 8092 bytes
 	.export level_data_blastprocessing
 	level_data_blastprocessing:
 	; Header
@@ -483,7 +460,7 @@
 		.byte song_blast_processing ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -493,29 +470,12 @@
 	; Level data
 		.incbin "EXPORTS/level/blastprocessing.lz.bin" ; Size: 5293
 
-	.export level_data_watertemple
-	level_data_watertemple:
-	; Header
-		.byte <sprite_data_watertemple ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_watertemple) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_watertemple >> 13) ;_________ Sprite data bank
-		.byte song_cant_let_go ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
-		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
-		.byte $00 ;______________________________________ Starting background color
-		.byte $0F ;______________________________________ Starting ground color
-		.byte 57 ;_______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/watertemple.lz.bin" ; Size: 2796
-
+	sprite_data_clubstep:	; Size: 2786
+		.incbin "EXPORTS/sprite/clubstep.bin"
 	.align 8192
 
 
-; Data bank 12, total bank size: 8116 bytes
+; Data bank 12, total bank size: 8085 bytes
 	.export level_data_kappaclysm
 	level_data_kappaclysm:
 	; Header
@@ -525,7 +485,7 @@
 		.byte song_atthespeedoflight ;__________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -535,29 +495,29 @@
 	; Level data
 		.incbin "EXPORTS/level/kappaclysm.lz.bin" ; Size: 5063
 
-	.export level_data_dorabaebasic6
-	level_data_dorabaebasic6:
+	.export level_data_cycles
+	level_data_cycles:
 	; Header
-		.byte <sprite_data_dorabaebasic6 ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_dorabaebasic6) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_dorabaebasic6 >> 13) ;_________ Sprite data bank
-		.byte song_theory_of_everything ;__________________ Song ID
-		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
-		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
-		.byte $0F ;________________________________________ Starting background color
-		.byte $0F ;________________________________________ Starting ground color
-		.byte 27 ;_________________________________________ Level height
+		.byte <sprite_data_cycles ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_cycles) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_cycles >> 13) ;_________ Sprite data bank
+		.byte song_cycles ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
+		.byte $04 ;_________________________________ Starting background color
+		.byte $14 ;_________________________________ Starting ground color
+		.byte 27 ;__________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/dorabaebasic6.lz.bin" ; Size: 3027
+		.incbin "EXPORTS/level/cycles.lz.bin" ; Size: 2996
 
 	.align 8192
 
 
-; Data bank 13, total bank size: 8142 bytes
+; Data bank 13, total bank size: 8027 bytes
 	.export level_data_clutterfunk
 	level_data_clutterfunk:
 	; Header
@@ -567,7 +527,7 @@
 		.byte song_clutterfunk ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -576,6 +536,76 @@
 		.byte 27 ;_______________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/clutterfunk.lz.bin" ; Size: 4816
+
+	.export level_data_firetemple
+	level_data_firetemple:
+	; Header
+		.byte <sprite_data_firetemple ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_firetemple) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_firetemple >> 13) ;_________ Sprite data bank
+		.byte song_base_after_base ;____________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESB << 4) | _BLOCKSB ;______________ Spike Set, Block Set
+		.byte $0F ;_____________________________________ Starting background color
+		.byte $0F ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/firetemple.lz.bin" ; Size: 3185
+
+	.align 8192
+
+
+; Data bank 14, total bank size: 7885 bytes
+	.export level_data_extraordinaryexcitement_1
+	level_data_extraordinaryexcitement_1:
+	; Level data
+		.incbin "EXPORTS/level/extraordinaryexcitement.lz.1.bin" ; Size: 4611
+
+	.export level_data_funnygameholiday
+	level_data_funnygameholiday:
+	; Header
+		.byte <sprite_data_funnygameholiday ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_funnygameholiday) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_funnygameholiday >> 13) ;_________ Sprite data bank
+		.byte song_stereo_madness ;___________________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;____________________ Spike Set, Block Set
+		.byte $0F ;___________________________________________ Starting background color
+		.byte $0F ;___________________________________________ Starting ground color
+		.byte 27 ;____________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/funnygameholiday.lz.bin" ; Size: 3261
+
+	.align 8192
+
+
+; Data bank 15, total bank size: 7828 bytes
+	.export level_data_electromanadventures
+	level_data_electromanadventures:
+	; Header
+		.byte <sprite_data_electromanadventures ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_electromanadventures) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_electromanadventures >> 13) ;_________ Sprite data bank
+		.byte song_electroman_adventures ;________________________ Song ID
+		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_______________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECOCLOUD ;_____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________________________ Spike Set, Block Set
+		.byte $02 ;_______________________________________________ Starting background color
+		.byte $01 ;_______________________________________________ Starting ground color
+		.byte 27 ;________________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/electromanadventures.lz.bin" ; Size: 4502
 
 	.export level_data_dorabaebasic4
 	level_data_dorabaebasic4:
@@ -586,7 +616,7 @@
 		.byte song_electrodynamix ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -599,62 +629,7 @@
 	.align 8192
 
 
-; Data bank 14, total bank size: 8177 bytes
-	.export level_data_extraordinaryexcitement_1
-	level_data_extraordinaryexcitement_1:
-	; Level data
-		.incbin "EXPORTS/level/extraordinaryexcitement.lz.1.bin" ; Size: 4611
-
-	sprite_data_electrodynamix:	; Size: 3566
-		.incbin "EXPORTS/sprite/electrodynamix.bin"
-	.align 8192
-
-
-; Data bank 15, total bank size: 8165 bytes
-	.export level_data_electromanadventures
-	level_data_electromanadventures:
-	; Header
-		.byte <sprite_data_electromanadventures ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_electromanadventures) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_electromanadventures >> 13) ;_________ Sprite data bank
-		.byte song_electroman_adventures ;________________________ Song ID
-		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_______________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECOCLOUD ;_____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________________________ Spike Set, Block Set
-		.byte $02 ;_______________________________________________ Starting background color
-		.byte $01 ;_______________________________________________ Starting ground color
-		.byte 27 ;________________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/electromanadventures.lz.bin" ; Size: 4502
-
-	.export level_data_funnygameholiday
-	level_data_funnygameholiday:
-	; Header
-		.byte <sprite_data_funnygameholiday ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_funnygameholiday) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_funnygameholiday >> 13) ;_________ Sprite data bank
-		.byte song_stereo_madness ;___________________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;____________________ Spike Set, Block Set
-		.byte $0F ;___________________________________________ Starting background color
-		.byte $0F ;___________________________________________ Starting ground color
-		.byte 27 ;____________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/funnygameholiday.lz.bin" ; Size: 3261
-
-	sprite_data_watertemple:	; Size: 376
-		.incbin "EXPORTS/sprite/watertemple.bin"
-	.align 8192
-
-
-; Data bank 16, total bank size: 8102 bytes
+; Data bank 16, total bank size: 7984 bytes
 	.export level_data_xstep
 	level_data_xstep:
 	; Header
@@ -664,7 +639,7 @@
 		.byte song_xstep ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_________ Spike Set, Block Set
@@ -674,15 +649,12 @@
 	; Level data
 		.incbin "EXPORTS/level/xstep.lz.bin" ; Size: 4405
 
-	.export level_data_rainbowtylenol_0
-	level_data_rainbowtylenol_0:
-	; Level data
-		.incbin "EXPORTS/level/rainbowtylenol.lz.1.bin" ; Size: 3684
-
+	sprite_data_electrodynamix:	; Size: 3566
+		.incbin "EXPORTS/sprite/electrodynamix.bin"
 	.align 8192
 
 
-; Data bank 17, total bank size: 8191 bytes
+; Data bank 17, total bank size: 7969 bytes
 	.export level_data_nightmare
 	level_data_nightmare:
 	; Header
@@ -692,7 +664,7 @@
 		.byte song_polargeist ;________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_____________ Spike Set, Block Set
@@ -702,8 +674,11 @@
 	; Level data
 		.incbin "EXPORTS/level/nightmare.lz.bin" ; Size: 4272
 
-	sprite_data_revolution:	; Size: 3906
-		.incbin "EXPORTS/sprite/revolution.bin"
+	.export level_data_rainbowtylenol_0
+	level_data_rainbowtylenol_0:
+	; Level data
+		.incbin "EXPORTS/level/rainbowtylenol.lz.1.bin" ; Size: 3684
+
 	.align 8192
 
 
@@ -717,7 +692,7 @@
 		.byte song_theory_of_everything ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________________ Spike Set, Block Set
@@ -736,7 +711,7 @@
 		.byte song_clubstep ;_____________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -749,51 +724,15 @@
 	.align 8192
 
 
-; Data bank 19, total bank size: 8097 bytes
+; Data bank 19, total bank size: 7852 bytes
 	sprite_data_funnygameholiday:	; Size: 3946
 		.incbin "EXPORTS/sprite/funnygameholiday.bin"
-	.export level_data_firetemple
-	level_data_firetemple:
-	; Header
-		.byte <sprite_data_firetemple ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_firetemple) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_firetemple >> 13) ;_________ Sprite data bank
-		.byte song_base_after_base ;____________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESB << 4) | _BLOCKSB ;______________ Spike Set, Block Set
-		.byte $0F ;_____________________________________ Starting background color
-		.byte $0F ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/firetemple.lz.bin" ; Size: 3185
-
-	.export level_data_thesewers
-	level_data_thesewers:
-	; Header
-		.byte <sprite_data_thesewers ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_thesewers) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_thesewers >> 13) ;_________ Sprite data bank
-		.byte song_scheming_weasel ;___________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($A0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($80) ;__________________________________ Y Scroll Position (low byte)
-		.byte (1 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $1A ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 48 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/thesewers.lz.bin" ; Size: 940
-
+	sprite_data_revolution:	; Size: 3906
+		.incbin "EXPORTS/sprite/revolution.bin"
 	.align 8192
 
 
-; Data bank 1A, total bank size: 8188 bytes
+; Data bank 1A, total bank size: 8091 bytes
 	.export level_data_timemachine
 	level_data_timemachine:
 	; Header
@@ -803,7 +742,7 @@
 		.byte song_time_machine ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
@@ -813,58 +752,58 @@
 	; Level data
 		.incbin "EXPORTS/level/timemachine.lz.bin" ; Size: 3137
 
-	.export level_data_cycles
-	level_data_cycles:
+	.export level_data_dorabaebasic6
+	level_data_dorabaebasic6:
 	; Header
-		.byte <sprite_data_cycles ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_cycles) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_cycles >> 13) ;_________ Sprite data bank
-		.byte song_cycles ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
-		.byte $04 ;_________________________________ Starting background color
-		.byte $14 ;_________________________________ Starting ground color
-		.byte 27 ;__________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/cycles.lz.bin" ; Size: 2996
-
-	.export level_data_baseafterbase
-	level_data_baseafterbase:
-	; Header
-		.byte <sprite_data_baseafterbase ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_baseafterbase) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_baseafterbase >> 13) ;_________ Sprite data bank
-		.byte song_base_after_base ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte <sprite_data_dorabaebasic6 ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_dorabaebasic6) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_dorabaebasic6 >> 13) ;_________ Sprite data bank
+		.byte song_theory_of_everything ;__________________ Song ID
+		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
-		.byte $11 ;________________________________________ Starting background color
-		.byte $11 ;________________________________________ Starting ground color
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
+		.byte $0F ;________________________________________ Starting background color
+		.byte $0F ;________________________________________ Starting ground color
 		.byte 27 ;_________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/baseafterbase.lz.bin" ; Size: 2016
+		.incbin "EXPORTS/level/dorabaebasic6.lz.bin" ; Size: 3027
 
+	sprite_data_sunshine:	; Size: 1901
+		.incbin "EXPORTS/sprite/sunshine.bin"
 	.align 8192
 
 
-; Data bank 1B, total bank size: 8163 bytes
+; Data bank 1B, total bank size: 8021 bytes
 	sprite_data_toe2:	; Size: 2891
 		.incbin "EXPORTS/sprite/toe2.bin"
-	sprite_data_clubstep:	; Size: 2786
-		.incbin "EXPORTS/sprite/clubstep.bin"
-	sprite_data_groundtospace:	; Size: 2486
-		.incbin "EXPORTS/sprite/groundtospace.bin"
+	.export level_data_watertemple
+	level_data_watertemple:
+	; Header
+		.byte <sprite_data_watertemple ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_watertemple) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_watertemple >> 13) ;_________ Sprite data bank
+		.byte song_cant_let_go ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
+		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
+		.byte $00 ;______________________________________ Starting background color
+		.byte $0F ;______________________________________ Starting ground color
+		.byte 57 ;_______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/watertemple.lz.bin" ; Size: 2796
+
+	sprite_data_timemachine:	; Size: 2321
+		.incbin "EXPORTS/sprite/timemachine.bin"
 	.align 8192
 
 
-; Data bank 1C, total bank size: 8005 bytes
+; Data bank 1C, total bank size: 8086 bytes
 	.export level_data_thelightningroad
 	level_data_thelightningroad:
 	; Header
@@ -874,7 +813,7 @@
 		.byte song_dry_out ;__________________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSA ;____________________ Spike Set, Block Set
@@ -884,8 +823,25 @@
 	; Level data
 		.incbin "EXPORTS/level/thelightningroad.lz.bin" ; Size: 2765
 
-	sprite_data_xstep:	; Size: 2616
-		.incbin "EXPORTS/sprite/xstep.bin"
+	.export level_data_retray
+	level_data_retray:
+	; Header
+		.byte <sprite_data_retray ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_retray) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_retray >> 13) ;_________ Sprite data bank
+		.byte song_retray ;_________________________ Song ID
+		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
+		.byte $0F ;_________________________________ Starting background color
+		.byte $0F ;_________________________________ Starting ground color
+		.byte 27 ;__________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/retray.lz.bin" ; Size: 2684
+
 	sprite_data_dorabaebasic4:	; Size: 2611
 		.incbin "EXPORTS/sprite/dorabaebasic4.bin"
 	.align 8192
@@ -903,7 +859,7 @@
 		.byte song_cant_let_go ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
@@ -918,7 +874,7 @@
 	.align 8192
 
 
-; Data bank 1E, total bank size: 8160 bytes
+; Data bank 1E, total bank size: 7494 bytes
 	.export level_data_thechallenge
 	level_data_thechallenge:
 	; Header
@@ -928,7 +884,7 @@
 		.byte song_the_challenge ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -938,16 +894,14 @@
 	; Level data
 		.incbin "EXPORTS/level/thechallenge.lz.bin" ; Size: 2509
 
-	sprite_data_theoryofeverything:	; Size: 2281
-		.incbin "EXPORTS/sprite/theoryofeverything.bin"
-	sprite_data_nightmare:	; Size: 2246
-		.incbin "EXPORTS/sprite/nightmare.bin"
-	sprite_data_stereomadness:	; Size: 1111
-		.incbin "EXPORTS/sprite/stereomadness.bin"
+	sprite_data_dash:	; Size: 2486
+		.incbin "EXPORTS/sprite/dash.bin"
+	sprite_data_groundtospace:	; Size: 2486
+		.incbin "EXPORTS/sprite/groundtospace.bin"
 	.align 8192
 
 
-; Data bank 1F, total bank size: 8170 bytes
+; Data bank 1F, total bank size: 8106 bytes
 	.export level_data_leveleasy
 	level_data_leveleasy:
 	; Header
@@ -957,7 +911,7 @@
 		.byte song_stereo_madness ;____________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -969,8 +923,25 @@
 
 	sprite_data_cycles:	; Size: 2086
 		.incbin "EXPORTS/sprite/cycles.bin"
-	sprite_data_sunshine:	; Size: 1901
-		.incbin "EXPORTS/sprite/sunshine.bin"
+	.export level_data_cantletgo
+	level_data_cantletgo:
+	; Header
+		.byte <sprite_data_cantletgo ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_cantletgo) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_cantletgo >> 13) ;_________ Sprite data bank
+		.byte song_cant_let_go ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
+		.byte $14 ;____________________________________ Starting background color
+		.byte $04 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/cantletgo.lz.bin" ; Size: 2040
+
 	.export level_data_stereomadness
 	level_data_stereomadness:
 	; Header
@@ -980,7 +951,7 @@
 		.byte song_stereo_madness ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
@@ -990,43 +961,43 @@
 	; Level data
 		.incbin "EXPORTS/level/stereomadness.lz.bin" ; Size: 1842
 
-	sprite_data_thetower:	; Size: 216
-		.incbin "EXPORTS/sprite/thetower.bin"
 	.align 8192
 
 
-; Data bank 20, total bank size: 8177 bytes
+; Data bank 20, total bank size: 8075 bytes
 	sprite_data_deadlocked:	; Size: 1846
 		.incbin "EXPORTS/sprite/deadlocked.bin"
+	.export level_data_polargeist
+	level_data_polargeist:
+	; Header
+		.byte <sprite_data_polargeist ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_polargeist) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_polargeist >> 13) ;_________ Sprite data bank
+		.byte song_polargeist ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
+		.byte $2A ;_____________________________________ Starting background color
+		.byte $1A ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/polargeist.lz.bin" ; Size: 1743
+
+	sprite_data_thelightningroad:	; Size: 1721
+		.incbin "EXPORTS/sprite/thelightningroad.bin"
 	sprite_data_lostinthewoods:	; Size: 1671
 		.incbin "EXPORTS/sprite/lostinthewoods.bin"
-	sprite_data_hexagonforce:	; Size: 1631
-		.incbin "EXPORTS/sprite/hexagonforce.bin"
-	.export level_data_dryout
-	level_data_dryout:
-	; Header
-		.byte <sprite_data_dryout ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_dryout) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_dryout >> 13) ;_________ Sprite data bank
-		.byte song_dry_out ;________________________ Song ID
-		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
-		.byte $16 ;_________________________________ Starting background color
-		.byte $16 ;_________________________________ Starting ground color
-		.byte 27 ;__________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/dryout.lz.bin" ; Size: 1520
-
-	sprite_data_subzero:	; Size: 1496
-		.incbin "EXPORTS/sprite/subzero.bin"
+	sprite_data_leveleasy:	; Size: 1081
+		.incbin "EXPORTS/sprite/leveleasy.bin"
 	.align 8192
 
 
-; Data bank 21, total bank size: 8098 bytes
+; Data bank 21, total bank size: 7353 bytes
+	sprite_data_subzero:	; Size: 1496
+		.incbin "EXPORTS/sprite/subzero.bin"
 	sprite_data_fingerdash:	; Size: 1491
 		.incbin "EXPORTS/sprite/fingerdash.bin"
 	.export level_data_backontrack
@@ -1038,7 +1009,7 @@
 		.byte song_back_on_track ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
@@ -1059,7 +1030,7 @@
 		.byte song_desert_city ;______________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($A0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($80) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($60) ;_________________________________ Y Scroll Position (low byte)
 		.byte (1 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_____________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -1069,14 +1040,16 @@
 	; Level data
 		.incbin "EXPORTS/level/thetower.lz.bin" ; Size: 1324
 
+	sprite_data_thetower:	; Size: 216
+		.incbin "EXPORTS/sprite/thetower.bin"
+	.align 8192
+
+
+; Data bank 22, total bank size: 8073 bytes
 	sprite_data_jumper:	; Size: 1246
 		.incbin "EXPORTS/sprite/jumper.bin"
 	sprite_data_polargeist:	; Size: 1211
 		.incbin "EXPORTS/sprite/polargeist.bin"
-	.align 8192
-
-
-; Data bank 22, total bank size: 8179 bytes
 	.export level_data_thecellar
 	level_data_thecellar:
 	; Header
@@ -1086,7 +1059,7 @@
 		.byte song_scheming_weasel ;___________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (1 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -1098,28 +1071,55 @@
 
 	sprite_data_baseafterbase:	; Size: 1146
 		.incbin "EXPORTS/sprite/baseafterbase.bin"
+	sprite_data_stereomadness:	; Size: 1111
+		.incbin "EXPORTS/sprite/stereomadness.bin"
 	sprite_data_firetemple:	; Size: 1111
 		.incbin "EXPORTS/sprite/firetemple.bin"
 	sprite_data_shadowtemple:	; Size: 1101
 		.incbin "EXPORTS/sprite/shadowtemple.bin"
-	sprite_data_leveleasy:	; Size: 1081
-		.incbin "EXPORTS/sprite/leveleasy.bin"
+	.align 8192
+
+
+; Data bank 23, total bank size: 7383 bytes
 	sprite_data_kappaclysm:	; Size: 1066
 		.incbin "EXPORTS/sprite/kappaclysm.bin"
 	sprite_data_dryout:	; Size: 1061
 		.incbin "EXPORTS/sprite/dryout.bin"
-	sprite_data_thechallenge:	; Size: 466
-		.incbin "EXPORTS/sprite/thechallenge.bin"
-	.align 8192
+	.export level_data_thesewers
+	level_data_thesewers:
+	; Header
+		.byte <sprite_data_thesewers ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_thesewers) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_thesewers >> 13) ;_________ Sprite data bank
+		.byte song_scheming_weasel ;___________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($A0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($60) ;__________________________________ Y Scroll Position (low byte)
+		.byte (1 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $1A ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 48 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/thesewers.lz.bin" ; Size: 940
 
-
-; Data bank 23, total bank size: 2628 bytes
 	sprite_data_backontrack:	; Size: 911
 		.incbin "EXPORTS/sprite/backontrack.bin"
 	sprite_data_retray:	; Size: 861
 		.incbin "EXPORTS/sprite/retray.bin"
 	sprite_data_cantletgo:	; Size: 856
 		.incbin "EXPORTS/sprite/cantletgo.bin"
+	sprite_data_thechallenge:	; Size: 466
+		.incbin "EXPORTS/sprite/thechallenge.bin"
+	sprite_data_watertemple:	; Size: 376
+		.incbin "EXPORTS/sprite/watertemple.bin"
+	sprite_data_thesewers:	; Size: 341
+		.incbin "EXPORTS/sprite/thesewers.bin"
+	sprite_data_thesecrethollow:	; Size: 281
+		.incbin "EXPORTS/sprite/thesecrethollow.bin"
+	sprite_data_thecellar:	; Size: 211
+		.incbin "EXPORTS/sprite/thecellar.bin"
 	.align 8192
 
 

--- a/LEVELS/include/lvlset_B/all_level_data.s
+++ b/LEVELS/include/lvlset_B/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_magic_touch ;______________________ Song ID
 		.byte (1 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -36,7 +36,7 @@
 		.byte song_subtle_oddities ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -59,7 +59,7 @@
 		.byte song_birdbrain ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($10) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________ Spike Set, Block Set
@@ -82,7 +82,7 @@
 		.byte song_meltdown ;______________________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_________________ Spike Set, Block Set
@@ -105,7 +105,7 @@
 		.byte song_tetris_remix_final ;_____________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -128,7 +128,7 @@
 		.byte song_new_dash_city ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -151,7 +151,7 @@
 		.byte song_snow ;_________________________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;________________________ Spike Set, Block Set
@@ -174,7 +174,7 @@
 		.byte song_cryogenic ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -203,7 +203,7 @@
 		.byte song_raining_tacos ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($00) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -226,7 +226,7 @@
 		.byte song_check_out ;____________________________ Song ID
 		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -251,7 +251,7 @@
 		.byte song_snow ;__________________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -274,7 +274,7 @@
 		.byte song_fire_aura ;________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -302,7 +302,7 @@
 		.byte song_infiltration ;___________________________ Song ID
 		.byte (2 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -332,7 +332,7 @@
 		.byte song_dry_out ;__________________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;____________________ Spike Set, Block Set
@@ -366,7 +366,7 @@
 		.byte song_meowstuff ;_________________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
@@ -391,7 +391,7 @@
 		.byte song_dance_of_the_violins ;___________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -427,7 +427,7 @@
 		.byte song_glitch_gremlin ;__________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -454,7 +454,7 @@
 		.byte song_kesobomb ;_______________________ Song ID
 		.byte (2 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -485,7 +485,7 @@
 		.byte song_tiny_tunes ;________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -518,7 +518,7 @@
 		.byte song_the_explorer ;___________________ Song ID
 		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
@@ -537,7 +537,7 @@
 		.byte song_win_the_race ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
@@ -560,7 +560,7 @@
 		.byte song_chaoz_fantasy_extended ;______________ Song ID
 		.byte (1 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -579,7 +579,7 @@
 		.byte song_stereo_madness_2 ;______________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -613,7 +613,7 @@
 		.byte song_xenogenesis ;__________________________ Song ID
 		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -632,7 +632,7 @@
 		.byte song_against_the_odds_redux ;___________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;____________________ Spike Set, Block Set
@@ -655,7 +655,7 @@
 		.byte song_fantasy ;___________________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -680,7 +680,7 @@
 		.byte song_power_trip ;________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -699,7 +699,7 @@
 		.byte song_off_to_mars ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -722,7 +722,7 @@
 		.byte song_select_payment_type ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________________ Spike Set, Block Set
@@ -741,7 +741,7 @@
 		.byte song_pyrophoric_legacy_remix ;____________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -777,7 +777,7 @@
 		.byte song_ninox ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_________ Spike Set, Block Set
@@ -798,7 +798,7 @@
 		.byte song_factory_time ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
@@ -847,7 +847,7 @@
 		.byte song_driving_by_night ;________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________________ Spike Set, Block Set
@@ -876,7 +876,7 @@
 		.byte song_ultimatedestruction ;________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;______________________ Spike Set, Block Set
@@ -909,7 +909,7 @@
 		.byte song_dry_out ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set

--- a/LEVELS/include/lvlset_C/all_level_data.s
+++ b/LEVELS/include/lvlset_C/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_future_funk_pt1 ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -54,7 +54,7 @@
 		.byte song_carefree_victory_remix ;__________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________________ Spike Set, Block Set
@@ -77,7 +77,7 @@
 		.byte song_somewhere_in_a_forest ;______________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;______________________ Spike Set, Block Set
@@ -109,7 +109,7 @@
 		.byte song_astronomical_expedition ;________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________________ Starting game mode and speed
 		.byte ($00) ;_______________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________________ Spike Set, Block Set
@@ -128,15 +128,13 @@
 	.align 8192
 
 
-; Data bank 08, total bank size: 8057 bytes
+; Data bank 08, total bank size: 7531 bytes
 	sprite_data_astronomicalexpedition:	; Size: 7531
 		.incbin "EXPORTS/sprite/astronomicalexpedition.bin"
-	sprite_data_madness:	; Size: 526
-		.incbin "EXPORTS/sprite/madness.bin"
 	.align 8192
 
 
-; Data bank 09, total bank size: 7974 bytes
+; Data bank 09, total bank size: 7258 bytes
 	.export level_data_chaozimpact
 	level_data_chaozimpact:
 	; Header
@@ -146,7 +144,7 @@
 		.byte song_speed_racer ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -156,12 +154,10 @@
 	; Level data
 		.incbin "EXPORTS/level/chaozimpact.lz.bin" ; Size: 7245
 
-	sprite_data_movie:	; Size: 716
-		.incbin "EXPORTS/sprite/movie.bin"
 	.align 8192
 
 
-; Data bank 0A, total bank size: 8179 bytes
+; Data bank 0A, total bank size: 7190 bytes
 	.export level_data_rotd
 	level_data_rotd:
 	; Header
@@ -171,7 +167,7 @@
 		.byte song_mario_kart_7__rainbow_road_remix ;___ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;______________ Spike Set, Block Set
@@ -181,8 +177,29 @@
 	; Level data
 		.incbin "EXPORTS/level/rotd.lz.bin" ; Size: 7177
 
-	sprite_data_doubletripletrial:	; Size: 676
-		.incbin "EXPORTS/sprite/doubletripletrial.bin"
+	.align 8192
+
+
+; Data bank 0B, total bank size: 7403 bytes
+	.export level_data_ninecircleseasy
+	level_data_ninecircleseasy:
+	; Header
+		.byte <sprite_data_ninecircleseasy ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_ninecircleseasy) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_ninecircleseasy >> 13) ;_________ Sprite data bank
+		.byte song_nine_circles ;____________________________ Song ID
+		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
+		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESC << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
+		.byte $06 ;__________________________________________ Starting background color
+		.byte $16 ;__________________________________________ Starting ground color
+		.byte 27 ;___________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/ninecircleseasy.lz.bin" ; Size: 7077
+
 	.export level_data_thetripletrial
 	level_data_thetripletrial:
 	; Header
@@ -192,7 +209,7 @@
 		.byte song_dastardly ;______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -205,30 +222,7 @@
 	.align 8192
 
 
-; Data bank 0B, total bank size: 7090 bytes
-	.export level_data_ninecircleseasy
-	level_data_ninecircleseasy:
-	; Header
-		.byte <sprite_data_ninecircleseasy ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_ninecircleseasy) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_ninecircleseasy >> 13) ;_________ Sprite data bank
-		.byte song_nine_circles ;____________________________ Song ID
-		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
-		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESC << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
-		.byte $06 ;__________________________________________ Starting background color
-		.byte $16 ;__________________________________________ Starting ground color
-		.byte 27 ;___________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/ninecircleseasy.lz.bin" ; Size: 7077
-
-	.align 8192
-
-
-; Data bank 0C, total bank size: 8157 bytes
+; Data bank 0C, total bank size: 7390 bytes
 	.export level_data_endgame
 	level_data_endgame:
 	; Header
@@ -238,7 +232,7 @@
 		.byte song_endgame_full ;____________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;____________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________ Spike Set, Block Set
@@ -248,12 +242,15 @@
 	; Level data
 		.incbin "EXPORTS/level/endgame.lz.bin" ; Size: 7018
 
-	sprite_data_chromaticexpedition:	; Size: 1126
-		.incbin "EXPORTS/sprite/chromaticexpedition.bin"
+	.export level_data_astronomicalexpedition_3
+	level_data_astronomicalexpedition_3:
+	; Level data
+		.incbin "EXPORTS/level/astronomicalexpedition.lz.3.bin" ; Size: 359
+
 	.align 8192
 
 
-; Data bank 0D, total bank size: 8183 bytes
+; Data bank 0D, total bank size: 7924 bytes
 	.export level_data_dastardly
 	level_data_dastardly:
 	; Header
@@ -263,7 +260,7 @@
 		.byte song_dastardly ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($70) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($30) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($10) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -272,6 +269,90 @@
 		.byte 27 ;_____________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/dastardly.lz.bin" ; Size: 6470
+
+	.export level_data_movie
+	level_data_movie:
+	; Header
+		.byte <sprite_data_movie ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_movie) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_movie >> 13) ;_________ Sprite data bank
+		.byte song_stereo_madness ;________________ Song ID
+		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
+		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_________ Spike Set, Block Set
+		.byte $0F ;________________________________ Starting background color
+		.byte $0F ;________________________________ Starting ground color
+		.byte 32 ;_________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/movie.lz.bin" ; Size: 1428
+
+	.align 8192
+
+
+; Data bank 0E, total bank size: 7983 bytes
+	.export level_data_clutterfunk2
+	level_data_clutterfunk2:
+	; Header
+		.byte <sprite_data_clutterfunk2 ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_clutterfunk2) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_clutterfunk2 >> 13) ;_________ Sprite data bank
+		.byte song_clutterfunk_2 ;________________________ Song ID
+		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
+		.byte $0F ;_______________________________________ Starting background color
+		.byte $0F ;_______________________________________ Starting ground color
+		.byte 27 ;________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/clutterfunk2.lz.bin" ; Size: 6453
+
+	.export level_data_feather
+	level_data_feather:
+	; Header
+		.byte <sprite_data_feather ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_feather) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_feather >> 13) ;_________ Sprite data bank
+		.byte song_aether_new ;______________________ Song ID
+		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
+		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
+		.byte $01 ;__________________________________ Starting background color
+		.byte $0F ;__________________________________ Starting ground color
+		.byte 27 ;___________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/feather.lz.bin" ; Size: 1504
+
+	.align 8192
+
+
+; Data bank 0F, total bank size: 8148 bytes
+	.export level_data_solarcircles
+	level_data_solarcircles:
+	; Header
+		.byte <sprite_data_solarcircles ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_solarcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_solarcircles >> 13) ;_________ Sprite data bank
+		.byte song_solar_wind ;___________________________ Song ID
+		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
+		.byte $0F ;_______________________________________ Starting background color
+		.byte $0F ;_______________________________________ Starting ground color
+		.byte 31 ;________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/solarcircles.lz.bin" ; Size: 6435
 
 	.export level_data_short_kings
 	level_data_short_kings:
@@ -282,7 +363,7 @@
 		.byte song_load ;________________________________ Song ID
 		.byte (3 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($00) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -295,93 +376,7 @@
 	.align 8192
 
 
-; Data bank 0E, total bank size: 8182 bytes
-	.export level_data_clutterfunk2
-	level_data_clutterfunk2:
-	; Header
-		.byte <sprite_data_clutterfunk2 ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_clutterfunk2) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_clutterfunk2 >> 13) ;_________ Sprite data bank
-		.byte song_clutterfunk_2 ;________________________ Song ID
-		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
-		.byte $0F ;_______________________________________ Starting background color
-		.byte $0F ;_______________________________________ Starting ground color
-		.byte 27 ;________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/clutterfunk2.lz.bin" ; Size: 6453
-
-	sprite_data_greif:	; Size: 1716
-		.incbin "EXPORTS/sprite/greif.bin"
-	.align 8192
-
-
-; Data bank 0F, total bank size: 8153 bytes
-	.export level_data_solarcircles
-	level_data_solarcircles:
-	; Header
-		.byte <sprite_data_solarcircles ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_solarcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_solarcircles >> 13) ;_________ Sprite data bank
-		.byte song_solar_wind ;___________________________ Song ID
-		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
-		.byte $0F ;_______________________________________ Starting background color
-		.byte $0F ;_______________________________________ Starting ground color
-		.byte 31 ;________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/solarcircles.lz.bin" ; Size: 6435
-
-	.export level_data_movie
-	level_data_movie:
-	; Header
-		.byte <sprite_data_movie ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_movie) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_movie >> 13) ;_________ Sprite data bank
-		.byte song_stereo_madness ;________________ Song ID
-		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
-		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_________ Spike Set, Block Set
-		.byte $0F ;________________________________ Starting background color
-		.byte $0F ;________________________________ Starting ground color
-		.byte 32 ;_________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/movie.lz.bin" ; Size: 1428
-
-	.export level_data_doubletripletrial
-	level_data_doubletripletrial:
-	; Header
-		.byte <sprite_data_doubletripletrial ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_doubletripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_doubletripletrial >> 13) ;_________ Sprite data bank
-		.byte song_dastardly ;_________________________________ Song ID
-		.byte (4 << 4) | 0 ;___________________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
-		.byte $00 ;____________________________________________ Starting background color
-		.byte $00 ;____________________________________________ Starting ground color
-		.byte 27 ;_____________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/doubletripletrial.lz.bin" ; Size: 251
-
-	.align 8192
-
-
-; Data bank 10, total bank size: 8161 bytes
+; Data bank 10, total bank size: 7598 bytes
 	.export level_data_decode
 	level_data_decode:
 	; Header
@@ -391,7 +386,7 @@
 		.byte song_endgame_full ;___________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -401,6 +396,72 @@
 	; Level data
 		.incbin "EXPORTS/level/decode.lz.bin" ; Size: 5869
 
+	sprite_data_greif:	; Size: 1716
+		.incbin "EXPORTS/sprite/greif.bin"
+	.align 8192
+
+
+; Data bank 11, total bank size: 7653 bytes
+	.export level_data_overawed
+	level_data_overawed:
+	; Header
+		.byte <sprite_data_overawed ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_overawed) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_overawed >> 13) ;_________ Sprite data bank
+		.byte song_deep_swim ;________________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSD ;____________ Spike Set, Block Set
+		.byte $0F ;___________________________________ Starting background color
+		.byte $0F ;___________________________________ Starting ground color
+		.byte 27 ;____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/overawed.lz.bin" ; Size: 5859
+
+	sprite_data_storymadness:	; Size: 1781
+		.incbin "EXPORTS/sprite/storymadness.bin"
+	.align 8192
+
+
+; Data bank 12, total bank size: 7543 bytes
+	.export level_data_dorabaebasic7
+	level_data_dorabaebasic7:
+	; Header
+		.byte <sprite_data_dorabaebasic7 ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_dorabaebasic7) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_dorabaebasic7 >> 13) ;_________ Sprite data bank
+		.byte song_clownparty_remix ;______________________ Song ID
+		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
+		.byte $0F ;________________________________________ Starting background color
+		.byte $0F ;________________________________________ Starting ground color
+		.byte 57 ;_________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/dorabaebasic7.lz.bin" ; Size: 5709
+
+	sprite_data_outerspace:	; Size: 1821
+		.incbin "EXPORTS/sprite/outerspace.bin"
+	.align 8192
+
+
+; Data bank 13, total bank size: 7647 bytes
+	sprite_data_clutterfunk2:	; Size: 5546
+		.incbin "EXPORTS/sprite/clutterfunk2.bin"
+	sprite_data_somewhereinaforest:	; Size: 2101
+		.incbin "EXPORTS/sprite/somewhereinaforest.bin"
+	.align 8192
+
+
+; Data bank 14, total bank size: 7800 bytes
+	sprite_data_carefreevictory:	; Size: 5521
+		.incbin "EXPORTS/sprite/carefreevictory.bin"
 	.export level_data_unity
 	level_data_unity:
 	; Header
@@ -410,7 +471,7 @@
 		.byte song_unity ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -423,86 +484,9 @@
 	.align 8192
 
 
-; Data bank 11, total bank size: 7973 bytes
-	.export level_data_overawed
-	level_data_overawed:
-	; Header
-		.byte <sprite_data_overawed ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_overawed) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_overawed >> 13) ;_________ Sprite data bank
-		.byte song_deep_swim ;________________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSD ;____________ Spike Set, Block Set
-		.byte $0F ;___________________________________ Starting background color
-		.byte $0F ;___________________________________ Starting ground color
-		.byte 27 ;____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/overawed.lz.bin" ; Size: 5859
-
-	sprite_data_somewhereinaforest:	; Size: 2101
-		.incbin "EXPORTS/sprite/somewhereinaforest.bin"
-	.align 8192
-
-
-; Data bank 12, total bank size: 8119 bytes
-	.export level_data_dorabaebasic7
-	level_data_dorabaebasic7:
-	; Header
-		.byte <sprite_data_dorabaebasic7 ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_dorabaebasic7) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_dorabaebasic7 >> 13) ;_________ Sprite data bank
-		.byte song_clownparty_remix ;______________________ Song ID
-		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
-		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
-		.byte $0F ;________________________________________ Starting background color
-		.byte $0F ;________________________________________ Starting ground color
-		.byte 57 ;_________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/dorabaebasic7.lz.bin" ; Size: 5709
-
-	sprite_data_overawed:	; Size: 1826
-		.incbin "EXPORTS/sprite/overawed.bin"
-	sprite_data_nicktoons:	; Size: 571
-		.incbin "EXPORTS/sprite/nicktoons.bin"
-	.align 8192
-
-
-; Data bank 13, total bank size: 8065 bytes
-	sprite_data_clutterfunk2:	; Size: 5546
-		.incbin "EXPORTS/sprite/clutterfunk2.bin"
-	.export level_data_nicktoons
-	level_data_nicktoons:
-	; Header
-		.byte <sprite_data_nicktoons ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_nicktoons) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_nicktoons >> 13) ;_________ Sprite data bank
-		.byte song_unity ;_____________________________ Song ID
-		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($00) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $28 ;____________________________________ Starting background color
-		.byte $27 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/nicktoons.lz.bin" ; Size: 2506
-
-	.align 8192
-
-
-; Data bank 14, total bank size: 8034 bytes
-	sprite_data_carefreevictory:	; Size: 5521
-		.incbin "EXPORTS/sprite/carefreevictory.bin"
+; Data bank 15, total bank size: 8019 bytes
+	sprite_data_rotd:	; Size: 5506
+		.incbin "EXPORTS/sprite/rotd.bin"
 	.export level_data_hungrymanadventures
 	level_data_hungrymanadventures:
 	; Header
@@ -512,7 +496,7 @@
 		.byte song_hungryman_adventures ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________________ Spike Set, Block Set
@@ -525,17 +509,7 @@
 	.align 8192
 
 
-; Data bank 15, total bank size: 8103 bytes
-	sprite_data_rotd:	; Size: 5506
-		.incbin "EXPORTS/sprite/rotd.bin"
-	sprite_data_storymadness:	; Size: 1781
-		.incbin "EXPORTS/sprite/storymadness.bin"
-	sprite_data_short_kings:	; Size: 816
-		.incbin "EXPORTS/sprite/short_kings.bin"
-	.align 8192
-
-
-; Data bank 16, total bank size: 8140 bytes
+; Data bank 16, total bank size: 8012 bytes
 	.export level_data_dorabaebasic8
 	level_data_dorabaebasic8:
 	; Header
@@ -545,7 +519,7 @@
 		.byte song_endgame_full ;__________________________ Song ID
 		.byte (1 << 4) | 2 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -555,10 +529,25 @@
 	; Level data
 		.incbin "EXPORTS/level/dorabaebasic8.lz.bin" ; Size: 5480
 
-	sprite_data_unity:	; Size: 1411
-		.incbin "EXPORTS/sprite/unity.bin"
-	sprite_data_dastardly:	; Size: 1236
-		.incbin "EXPORTS/sprite/dastardly.bin"
+	.export level_data_nicktoons
+	level_data_nicktoons:
+	; Header
+		.byte <sprite_data_nicktoons ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_nicktoons) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_nicktoons >> 13) ;_________ Sprite data bank
+		.byte song_unity ;_____________________________ Song ID
+		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($00) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $28 ;____________________________________ Starting background color
+		.byte $27 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/nicktoons.lz.bin" ; Size: 2506
+
 	.align 8192
 
 
@@ -572,7 +561,7 @@
 		.byte song_cosmic_dolphin ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($00) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_________________ Spike Set, Block Set
@@ -608,7 +597,7 @@
 		.byte song_somewhere_in_a_forest ;_______________________ Song ID
 		.byte (0 << 4) | 3 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________________ Spike Set, Block Set
@@ -627,7 +616,7 @@
 		.byte song_cycles ;______________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -640,7 +629,7 @@
 	.align 8192
 
 
-; Data bank 1A, total bank size: 8187 bytes
+; Data bank 1A, total bank size: 8133 bytes
 	.export level_data_storymadness
 	level_data_storymadness:
 	; Header
@@ -650,7 +639,7 @@
 		.byte song_stereo_madness ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;________________ Spike Set, Block Set
@@ -660,25 +649,8 @@
 	; Level data
 		.incbin "EXPORTS/level/storymadness.lz.bin" ; Size: 4474
 
-	.export level_data_dreamer
-	level_data_dreamer:
-	; Header
-		.byte <sprite_data_dreamer ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_dreamer) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_dreamer >> 13) ;_________ Sprite data bank
-		.byte song_midnight ;________________________ Song ID
-		.byte (1 << 4) | 0 ;_________________________ Starting game mode and speed
-		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;___________ Spike Set, Block Set
-		.byte $0F ;__________________________________ Starting background color
-		.byte $0F ;__________________________________ Starting ground color
-		.byte 27 ;___________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/dreamer.lz.bin" ; Size: 3687
-
+	sprite_data_cosmicdolphin:	; Size: 3646
+		.incbin "EXPORTS/sprite/cosmicdolphin.bin"
 	.align 8192
 
 
@@ -700,7 +672,7 @@
 		.byte song_the_beginning_of_time ;_________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -728,7 +700,7 @@
 		.byte song_stalemate_greif_cut ;___________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -747,7 +719,7 @@
 		.byte song_sunslammer ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -768,7 +740,7 @@
 	.align 8192
 
 
-; Data bank 1F, total bank size: 8122 bytes
+; Data bank 1F, total bank size: 7450 bytes
 	.export level_data_illusion
 	level_data_illusion:
 	; Header
@@ -778,7 +750,7 @@
 		.byte song_operation_evolution ;______________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -788,24 +760,56 @@
 	; Level data
 		.incbin "EXPORTS/level/illusion.lz.bin" ; Size: 3737
 
-	sprite_data_cosmicdolphin:	; Size: 3646
-		.incbin "EXPORTS/sprite/cosmicdolphin.bin"
-	sprite_data_trolledfix:	; Size: 726
-		.incbin "EXPORTS/sprite/trolledfix.bin"
+	.export level_data_dreamer
+	level_data_dreamer:
+	; Header
+		.byte <sprite_data_dreamer ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_dreamer) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_dreamer >> 13) ;_________ Sprite data bank
+		.byte song_midnight ;________________________ Song ID
+		.byte (1 << 4) | 0 ;_________________________ Starting game mode and speed
+		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;___________ Spike Set, Block Set
+		.byte $0F ;__________________________________ Starting background color
+		.byte $0F ;__________________________________ Starting ground color
+		.byte 27 ;___________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/dreamer.lz.bin" ; Size: 3687
+
 	.align 8192
 
 
-; Data bank 20, total bank size: 8138 bytes
+; Data bank 20, total bank size: 7361 bytes
 	sprite_data_illusion:	; Size: 3641
 		.incbin "EXPORTS/sprite/illusion.bin"
 	sprite_data_dorabaebasic8:	; Size: 3456
 		.incbin "EXPORTS/sprite/dorabaebasic8.bin"
-	sprite_data_groundtoretray:	; Size: 1041
-		.incbin "EXPORTS/sprite/groundtoretray.bin"
+	.export level_data_doubletripletrial
+	level_data_doubletripletrial:
+	; Header
+		.byte <sprite_data_doubletripletrial ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_doubletripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_doubletripletrial >> 13) ;_________ Sprite data bank
+		.byte song_dastardly ;_________________________________ Song ID
+		.byte (4 << 4) | 0 ;___________________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
+		.byte $00 ;____________________________________________ Starting background color
+		.byte $00 ;____________________________________________ Starting ground color
+		.byte 27 ;_____________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/doubletripletrial.lz.bin" ; Size: 251
+
 	.align 8192
 
 
-; Data bank 21, total bank size: 8037 bytes
+; Data bank 21, total bank size: 7931 bytes
 	sprite_data_supercycles:	; Size: 3311
 		.incbin "EXPORTS/sprite/supercycles.bin"
 	.export level_data_groundtoretray
@@ -817,7 +821,7 @@
 		.byte song_ground_to_retray ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -827,39 +831,22 @@
 	; Level data
 		.incbin "EXPORTS/level/groundtoretray.lz.bin" ; Size: 3196
 
-	.export level_data_feather
-	level_data_feather:
-	; Header
-		.byte <sprite_data_feather ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_feather) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_feather >> 13) ;_________ Sprite data bank
-		.byte song_aether_new ;______________________ Song ID
-		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
-		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
-		.byte $01 ;__________________________________ Starting background color
-		.byte $0F ;__________________________________ Starting ground color
-		.byte 27 ;___________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/feather.lz.bin" ; Size: 1504
-
+	sprite_data_unity:	; Size: 1411
+		.incbin "EXPORTS/sprite/unity.bin"
 	.align 8192
 
 
-; Data bank 22, total bank size: 7523 bytes
+; Data bank 22, total bank size: 7528 bytes
 	sprite_data_solarcircles:	; Size: 2911
 		.incbin "EXPORTS/sprite/solarcircles.bin"
 	sprite_data_dreamer:	; Size: 2791
 		.incbin "EXPORTS/sprite/dreamer.bin"
-	sprite_data_outerspace:	; Size: 1821
-		.incbin "EXPORTS/sprite/outerspace.bin"
+	sprite_data_overawed:	; Size: 1826
+		.incbin "EXPORTS/sprite/overawed.bin"
 	.align 8192
 
 
-; Data bank 23, total bank size: 8112 bytes
+; Data bank 23, total bank size: 7769 bytes
 	.export level_data_somewhereinaforest_0
 	level_data_somewhereinaforest_0:
 	; Level data
@@ -874,7 +861,7 @@
 		.byte song_youve_been_trolled ;_________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;______________ Spike Set, Block Set
@@ -888,8 +875,14 @@
 		.incbin "EXPORTS/sprite/hungrymanadventures.bin"
 	sprite_data_thetripletrial:	; Size: 1301
 		.incbin "EXPORTS/sprite/thetripletrial.bin"
+	sprite_data_dastardly:	; Size: 1236
+		.incbin "EXPORTS/sprite/dastardly.bin"
 	sprite_data_feather:	; Size: 1231
 		.incbin "EXPORTS/sprite/feather.bin"
+	.align 8192
+
+
+; Data bank 24, total bank size: 7418 bytes
 	.export level_data_madness
 	level_data_madness:
 	; Header
@@ -899,7 +892,7 @@
 		.byte song_c_madness ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
@@ -909,12 +902,23 @@
 	; Level data
 		.incbin "EXPORTS/level/madness.lz.bin" ; Size: 1207
 
-	.export level_data_astronomicalexpedition_3
-	level_data_astronomicalexpedition_3:
-	; Level data
-		.incbin "EXPORTS/level/astronomicalexpedition.lz.3.bin" ; Size: 359
-
+	sprite_data_chromaticexpedition:	; Size: 1126
+		.incbin "EXPORTS/sprite/chromaticexpedition.bin"
+	sprite_data_groundtoretray:	; Size: 1041
+		.incbin "EXPORTS/sprite/groundtoretray.bin"
+	sprite_data_short_kings:	; Size: 816
+		.incbin "EXPORTS/sprite/short_kings.bin"
+	sprite_data_trolledfix:	; Size: 726
+		.incbin "EXPORTS/sprite/trolledfix.bin"
+	sprite_data_movie:	; Size: 716
+		.incbin "EXPORTS/sprite/movie.bin"
+	sprite_data_doubletripletrial:	; Size: 676
+		.incbin "EXPORTS/sprite/doubletripletrial.bin"
+	sprite_data_nicktoons:	; Size: 571
+		.incbin "EXPORTS/sprite/nicktoons.bin"
+	sprite_data_madness:	; Size: 526
+		.incbin "EXPORTS/sprite/madness.bin"
 	.align 8192
 
 
-LEVEL_BANK_COUNT = 36
+LEVEL_BANK_COUNT = 37

--- a/LEVELS/include/lvlset_D/all_level_data.s
+++ b/LEVELS/include/lvlset_D/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_pursuit ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -45,7 +45,7 @@
 		.byte song_eon ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;_____________________ Starting game mode and speed
 		.byte ($B0) ;____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSA ;_______ Spike Set, Block Set
@@ -68,7 +68,7 @@
 		.byte song_sonic_blaster ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -91,7 +91,7 @@
 		.byte song_try_this ;__________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -114,7 +114,7 @@
 		.byte song_every_end_pt1 ;____________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;____________ Spike Set, Block Set
@@ -137,7 +137,7 @@
 		.byte song_death_moon ;________________________ Song ID
 		.byte (3 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -160,7 +160,7 @@
 		.byte song_sonic_blaster ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -183,7 +183,7 @@
 		.byte song_nine_circles ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -206,7 +206,7 @@
 		.byte song_atthespeedoflight2 ;________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -229,7 +229,7 @@
 		.byte song_clubstep ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -242,7 +242,7 @@
 	.align 8192
 
 
-; Data bank 0B, total bank size: 8080 bytes
+; Data bank 0B, total bank size: 7054 bytes
 	.export level_data_cataclysm
 	level_data_cataclysm:
 	; Header
@@ -252,7 +252,7 @@
 		.byte song_atthespeedoflight ;_________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -262,12 +262,10 @@
 	; Level data
 		.incbin "EXPORTS/level/cataclysm.lz.bin" ; Size: 7041
 
-	sprite_data_stalemate:	; Size: 1026
-		.incbin "EXPORTS/sprite/stalemate.bin"
 	.align 8192
 
 
-; Data bank 0C, total bank size: 8086 bytes
+; Data bank 0C, total bank size: 6830 bytes
 	.export level_data_fairydust
 	level_data_fairydust:
 	; Header
@@ -277,7 +275,7 @@
 		.byte song_fairydust ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -287,12 +285,10 @@
 	; Level data
 		.incbin "EXPORTS/level/fairydust.lz.bin" ; Size: 6817
 
-	sprite_data_everymadness:	; Size: 1256
-		.incbin "EXPORTS/sprite/everymadness.bin"
 	.align 8192
 
 
-; Data bank 0D, total bank size: 8192 bytes
+; Data bank 0D, total bank size: 6796 bytes
 	.export level_data_aftermath
 	level_data_aftermath:
 	; Header
@@ -302,7 +298,7 @@
 		.byte song_atthespeedoflight3 ;________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -312,12 +308,10 @@
 	; Level data
 		.incbin "EXPORTS/level/aftermath.lz.bin" ; Size: 6783
 
-	sprite_data_xx:	; Size: 1396
-		.incbin "EXPORTS/sprite/xx.bin"
 	.align 8192
 
 
-; Data bank 0E, total bank size: 8145 bytes
+; Data bank 0E, total bank size: 6958 bytes
 	.export level_data_invisiblelight
 	level_data_invisiblelight:
 	; Header
@@ -327,7 +321,7 @@
 		.byte song_blacklight ;_____________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -337,23 +331,40 @@
 	; Level data
 		.incbin "EXPORTS/level/invisiblelight.lz.bin" ; Size: 6760
 
-	.export level_data_trythisgd_2
-	level_data_trythisgd_2:
+	.export level_data_motion_1
+	level_data_motion_1:
 	; Level data
-		.incbin "EXPORTS/level/trythisgd.lz.1.bin" ; Size: 1372
+		.incbin "EXPORTS/level/motion.lz.1.bin" ; Size: 185
 
 	.align 8192
 
 
-; Data bank 0F, total bank size: 8072 bytes
+; Data bank 0F, total bank size: 7268 bytes
 	sprite_data_eon:	; Size: 6571
 		.incbin "EXPORTS/sprite/eon.bin"
-	sprite_data_aftermath:	; Size: 1501
-		.incbin "EXPORTS/sprite/aftermath.bin"
+	.export level_data_luckydraw
+	level_data_luckydraw:
+	; Header
+		.byte <sprite_data_luckydraw ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_luckydraw) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_luckydraw >> 13) ;_________ Sprite data bank
+		.byte song_every_end_pt1 ;_____________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/luckydraw.lz.bin" ; Size: 684
+
 	.align 8192
 
 
-; Data bank 10, total bank size: 6538 bytes
+; Data bank 10, total bank size: 7351 bytes
 	.export level_data_endorphinrush
 	level_data_endorphinrush:
 	; Header
@@ -363,7 +374,7 @@
 		.byte song_endorphins ;____________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -373,10 +384,15 @@
 	; Level data
 		.incbin "EXPORTS/level/endorphinrush.lz.bin" ; Size: 6525
 
+	.export level_data_eon_3
+	level_data_eon_3:
+	; Level data
+		.incbin "EXPORTS/level/eon.lz.1.bin" ; Size: 813
+
 	.align 8192
 
 
-; Data bank 11, total bank size: 6537 bytes
+; Data bank 11, total bank size: 7563 bytes
 	.export level_data_thermodynamix
 	level_data_thermodynamix:
 	; Header
@@ -386,7 +402,7 @@
 		.byte song_thermodynamix ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -396,6 +412,8 @@
 	; Level data
 		.incbin "EXPORTS/level/thermodynamix.lz.bin" ; Size: 6524
 
+	sprite_data_stalemate:	; Size: 1026
+		.incbin "EXPORTS/sprite/stalemate.bin"
 	.align 8192
 
 
@@ -409,7 +427,7 @@
 		.byte song_holography ;_________________ Song ID
 		.byte (1 << 4) | 0 ;____________________ Starting game mode and speed
 		.byte ($B0) ;___________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;_______ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;______ Spike Set, Block Set
@@ -424,7 +442,7 @@
 	.align 8192
 
 
-; Data bank 13, total bank size: 8169 bytes
+; Data bank 13, total bank size: 7864 bytes
 	.export level_data_eighto
 	level_data_eighto:
 	; Header
@@ -434,7 +452,7 @@
 		.byte song_eighto ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;__________ Spike Set, Block Set
@@ -444,8 +462,8 @@
 	; Level data
 		.incbin "EXPORTS/level/eighto.lz.bin" ; Size: 5730
 
-	sprite_data_deathmoon:	; Size: 2426
-		.incbin "EXPORTS/sprite/deathmoon.bin"
+	sprite_data_problematic:	; Size: 2121
+		.incbin "EXPORTS/sprite/problematic.bin"
 	.align 8192
 
 
@@ -459,7 +477,7 @@
 		.byte song_hell ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;_________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -474,7 +492,7 @@
 	.align 8192
 
 
-; Data bank 15, total bank size: 8130 bytes
+; Data bank 15, total bank size: 8075 bytes
 	.export level_data_deadlyclubstep
 	level_data_deadlyclubstep:
 	; Header
@@ -484,7 +502,7 @@
 		.byte song_clubstep ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -494,12 +512,12 @@
 	; Level data
 		.incbin "EXPORTS/level/deadlyclubstep.lz.bin" ; Size: 5276
 
-	sprite_data_pgclubstep:	; Size: 2841
-		.incbin "EXPORTS/sprite/pgclubstep.bin"
+	sprite_data_fairydust:	; Size: 2786
+		.incbin "EXPORTS/sprite/fairydust.bin"
 	.align 8192
 
 
-; Data bank 16, total bank size: 8179 bytes
+; Data bank 16, total bank size: 8049 bytes
 	.export level_data_stalemate
 	level_data_stalemate:
 	; Header
@@ -509,7 +527,7 @@
 		.byte song_stalemate ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -519,17 +537,12 @@
 	; Level data
 		.incbin "EXPORTS/level/stalemate.lz.bin" ; Size: 5195
 
-	sprite_data_fairydust:	; Size: 2786
-		.incbin "EXPORTS/sprite/fairydust.bin"
-	.export level_data_motion_1
-	level_data_motion_1:
-	; Level data
-		.incbin "EXPORTS/level/motion.lz.1.bin" ; Size: 185
-
+	sprite_data_pgclubstep:	; Size: 2841
+		.incbin "EXPORTS/sprite/pgclubstep.bin"
 	.align 8192
 
 
-; Data bank 17, total bank size: 7972 bytes
+; Data bank 17, total bank size: 7882 bytes
 	.export level_data_problematic
 	level_data_problematic:
 	; Header
@@ -539,7 +552,7 @@
 		.byte song_problematic ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -549,12 +562,12 @@
 	; Level data
 		.incbin "EXPORTS/level/problematic.lz.bin" ; Size: 4873
 
-	sprite_data_thermodynamix:	; Size: 3086
-		.incbin "EXPORTS/sprite/thermodynamix.bin"
+	sprite_data_eighto:	; Size: 2996
+		.incbin "EXPORTS/sprite/eighto.bin"
 	.align 8192
 
 
-; Data bank 18, total bank size: 7898 bytes
+; Data bank 18, total bank size: 7858 bytes
 	.export level_data_hi
 	level_data_hi:
 	; Header
@@ -564,7 +577,7 @@
 		.byte song_miami_hotline_vol_3 ;________ Song ID
 		.byte (1 << 4) | 0 ;____________________ Starting game mode and speed
 		.byte ($B0) ;___________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______ Spike Set, Block Set
@@ -574,38 +587,38 @@
 	; Level data
 		.incbin "EXPORTS/level/hi.lz.bin" ; Size: 4814
 
-	sprite_data_invisiblelight:	; Size: 3071
-		.incbin "EXPORTS/sprite/invisiblelight.bin"
-	.align 8192
-
-
-; Data bank 19, total bank size: 8144 bytes
-	.export level_data_everyend_6
-	level_data_everyend_6:
-	; Level data
-		.incbin "EXPORTS/level/everyend.lz.2.bin" ; Size: 4772
-
-	.export level_data_deathmoon_0
-	level_data_deathmoon_0:
-	; Level data
-		.incbin "EXPORTS/level/deathmoon.lz.1.bin" ; Size: 3372
-
-	.align 8192
-
-
-; Data bank 1A, total bank size: 7737 bytes
-	sprite_data_sonicwave:	; Size: 4706
-		.incbin "EXPORTS/sprite/sonicwave.bin"
 	sprite_data_trythisgd:	; Size: 3031
 		.incbin "EXPORTS/sprite/trythisgd.bin"
 	.align 8192
 
 
-; Data bank 1B, total bank size: 8042 bytes
+; Data bank 19, total bank size: 7843 bytes
+	.export level_data_everyend_6
+	level_data_everyend_6:
+	; Level data
+		.incbin "EXPORTS/level/everyend.lz.2.bin" ; Size: 4772
+
+	sprite_data_invisiblelight:	; Size: 3071
+		.incbin "EXPORTS/sprite/invisiblelight.bin"
+	.align 8192
+
+
+; Data bank 1A, total bank size: 7792 bytes
+	sprite_data_sonicwave:	; Size: 4706
+		.incbin "EXPORTS/sprite/sonicwave.bin"
+	sprite_data_thermodynamix:	; Size: 3086
+		.incbin "EXPORTS/sprite/thermodynamix.bin"
+	.align 8192
+
+
+; Data bank 1B, total bank size: 7898 bytes
 	sprite_data_endorphinrush:	; Size: 4526
 		.incbin "EXPORTS/sprite/endorphinrush.bin"
-	sprite_data_sonicblaster:	; Size: 3516
-		.incbin "EXPORTS/sprite/sonicblaster.bin"
+	.export level_data_deathmoon_0
+	level_data_deathmoon_0:
+	; Level data
+		.incbin "EXPORTS/level/deathmoon.lz.1.bin" ; Size: 3372
+
 	.align 8192
 
 
@@ -617,19 +630,14 @@
 	.align 8192
 
 
-; Data bank 1D, total bank size: 7572 bytes
+; Data bank 1D, total bank size: 7279 bytes
 	.export level_data_sonicwave_4
 	level_data_sonicwave_4:
 	; Level data
 		.incbin "EXPORTS/level/sonicwave.lz.1.bin" ; Size: 3763
 
-	sprite_data_eighto:	; Size: 2996
-		.incbin "EXPORTS/sprite/eighto.bin"
-	.export level_data_eon_3
-	level_data_eon_3:
-	; Level data
-		.incbin "EXPORTS/level/eon.lz.1.bin" ; Size: 813
-
+	sprite_data_sonicblaster:	; Size: 3516
+		.incbin "EXPORTS/sprite/sonicblaster.bin"
 	.align 8192
 
 
@@ -643,7 +651,7 @@
 	.align 8192
 
 
-; Data bank 1F, total bank size: 8087 bytes
+; Data bank 1F, total bank size: 7695 bytes
 	sprite_data_motion:	; Size: 2641
 		.incbin "EXPORTS/sprite/motion.bin"
 	.export level_data_everymadness
@@ -655,7 +663,7 @@
 		.byte song_every_madness ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;________________ Spike Set, Block Set
@@ -665,33 +673,25 @@
 	; Level data
 		.incbin "EXPORTS/level/everymadness.lz.bin" ; Size: 2615
 
-	sprite_data_problematic:	; Size: 2121
-		.incbin "EXPORTS/sprite/problematic.bin"
-	.export level_data_luckydraw
-	level_data_luckydraw:
-	; Header
-		.byte <sprite_data_luckydraw ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_luckydraw) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_luckydraw >> 13) ;_________ Sprite data bank
-		.byte song_every_end_pt1 ;_____________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/luckydraw.lz.bin" ; Size: 684
-
+	sprite_data_deathmoon:	; Size: 2426
+		.incbin "EXPORTS/sprite/deathmoon.bin"
 	.align 8192
 
 
-; Data bank 20, total bank size: 1701 bytes
+; Data bank 20, total bank size: 7226 bytes
 	sprite_data_everyend:	; Size: 1701
 		.incbin "EXPORTS/sprite/everyend.bin"
+	sprite_data_aftermath:	; Size: 1501
+		.incbin "EXPORTS/sprite/aftermath.bin"
+	sprite_data_xx:	; Size: 1396
+		.incbin "EXPORTS/sprite/xx.bin"
+	.export level_data_trythisgd_2
+	level_data_trythisgd_2:
+	; Level data
+		.incbin "EXPORTS/level/trythisgd.lz.1.bin" ; Size: 1372
+
+	sprite_data_everymadness:	; Size: 1256
+		.incbin "EXPORTS/sprite/everymadness.bin"
 	.align 8192
 
 

--- a/LEVELS/include/lvlset_E/all_level_data.s
+++ b/LEVELS/include/lvlset_E/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_atthespeedoflightfull ;_________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -45,7 +45,7 @@
 		.byte song_pyrophoric_xl ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -68,7 +68,7 @@
 		.byte song_cryogenic ;______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -91,7 +91,7 @@
 		.byte song_windfall ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -114,7 +114,7 @@
 		.byte song_slash_inferno ;_______________________________ Song ID
 		.byte (0 << 4) | 5 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________________ Spike Set, Block Set
@@ -137,7 +137,7 @@
 		.byte song_apoplexy ;___________________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -160,7 +160,7 @@
 		.byte song_careless ;__________________________ Song ID
 		.byte (1 << 4) | 1 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________ Spike Set, Block Set
@@ -173,7 +173,7 @@
 	.align 8192
 
 
-; Data bank 08, total bank size: 8175 bytes
+; Data bank 08, total bank size: 7864 bytes
 	.export level_data_slaughterhouse
 	level_data_slaughterhouse:
 	; Header
@@ -183,7 +183,7 @@
 		.byte song_lost ;___________________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -193,19 +193,15 @@
 	; Level data
 		.incbin "EXPORTS/level/slaughterhouse.lz.bin" ; Size: 7851
 
-	sprite_data_acropolis:	; Size: 311
-		.incbin "EXPORTS/sprite/acropolis.bin"
 	.align 8192
 
 
-; Data bank 09, total bank size: 8187 bytes
+; Data bank 09, total bank size: 7771 bytes
 	.export level_data_heliopolis_7
 	level_data_heliopolis_7:
 	; Level data
 		.incbin "EXPORTS/level/heliopolis.lz.1.bin" ; Size: 7771
 
-	sprite_data_foresttemple:	; Size: 416
-		.incbin "EXPORTS/sprite/foresttemple.bin"
 	.align 8192
 
 
@@ -219,7 +215,7 @@
 		.byte song_kratos ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -242,7 +238,7 @@
 		.byte song_golden_haze_not_retray ;_____________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -255,7 +251,7 @@
 	.align 8192
 
 
-; Data bank 0C, total bank size: 8171 bytes
+; Data bank 0C, total bank size: 7456 bytes
 	.export level_data_icdx
 	level_data_icdx:
 	; Header
@@ -265,7 +261,7 @@
 		.byte song_clubstep ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -275,12 +271,12 @@
 	; Level data
 		.incbin "EXPORTS/level/icdx.lz.bin" ; Size: 7132
 
-	sprite_data_wcropolix:	; Size: 1026
-		.incbin "EXPORTS/sprite/wcropolix.bin"
+	sprite_data_acropolis:	; Size: 311
+		.incbin "EXPORTS/sprite/acropolis.bin"
 	.align 8192
 
 
-; Data bank 0D, total bank size: 7991 bytes
+; Data bank 0D, total bank size: 7306 bytes
 	.export level_data_jawbreaker
 	level_data_jawbreaker:
 	; Header
@@ -290,7 +286,7 @@
 		.byte song_jawbreaker ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -300,12 +296,12 @@
 	; Level data
 		.incbin "EXPORTS/level/jawbreaker.lz.bin" ; Size: 6877
 
-	sprite_data_nullscapes:	; Size: 1101
-		.incbin "EXPORTS/sprite/nullscapes.bin"
+	sprite_data_foresttemple:	; Size: 416
+		.incbin "EXPORTS/sprite/foresttemple.bin"
 	.align 8192
 
 
-; Data bank 0E, total bank size: 8180 bytes
+; Data bank 0E, total bank size: 8096 bytes
 	.export level_data_azuronxolax
 	level_data_azuronxolax:
 	; Header
@@ -315,7 +311,7 @@
 		.byte song_endgame ;_____________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -325,15 +321,12 @@
 	; Level data
 		.incbin "EXPORTS/level/azuronxolax.lz.bin" ; Size: 6672
 
-	.export level_data_demoncryogenic_3
-	level_data_demoncryogenic_3:
-	; Level data
-		.incbin "EXPORTS/level/demoncryogenic.lz.1.bin" ; Size: 1495
-
+	sprite_data_explorers:	; Size: 1411
+		.incbin "EXPORTS/sprite/explorers.bin"
 	.align 8192
 
 
-; Data bank 0F, total bank size: 8046 bytes
+; Data bank 0F, total bank size: 8130 bytes
 	.export level_data_toeiiv2
 	level_data_toeiiv2:
 	; Header
@@ -343,7 +336,7 @@
 		.byte song_toe_2 ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________ Spike Set, Block Set
@@ -353,20 +346,23 @@
 	; Level data
 		.incbin "EXPORTS/level/toeiiv2.lz.bin" ; Size: 6622
 
-	sprite_data_explorers:	; Size: 1411
-		.incbin "EXPORTS/sprite/explorers.bin"
+	.export level_data_demoncryogenic_3
+	level_data_demoncryogenic_3:
+	; Level data
+		.incbin "EXPORTS/level/demoncryogenic.lz.1.bin" ; Size: 1495
+
 	.align 8192
 
 
-; Data bank 10, total bank size: 8117 bytes
+; Data bank 10, total bank size: 7877 bytes
 	sprite_data_respitev2:	; Size: 6266
 		.incbin "EXPORTS/sprite/respitev2.bin"
-	sprite_data_silentclubstep:	; Size: 1851
-		.incbin "EXPORTS/sprite/silentclubstep.bin"
+	sprite_data_gameover:	; Size: 1611
+		.incbin "EXPORTS/sprite/gameover.bin"
 	.align 8192
 
 
-; Data bank 11, total bank size: 8184 bytes
+; Data bank 11, total bank size: 7908 bytes
 	.export level_data_styx
 	level_data_styx:
 	; Header
@@ -376,7 +372,7 @@
 		.byte song_thermodynamix_acheron ;________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -386,25 +382,8 @@
 	; Level data
 		.incbin "EXPORTS/level/styx.lz.bin" ; Size: 6129
 
-	.export level_data_explorers
-	level_data_explorers:
-	; Header
-		.byte <sprite_data_explorers ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_explorers) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_explorers >> 13) ;_________ Sprite data bank
-		.byte song_explorers ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $03 ;____________________________________ Starting background color
-		.byte $03 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/explorers.lz.bin" ; Size: 2029
-
+	sprite_data_demonpark:	; Size: 1766
+		.incbin "EXPORTS/sprite/demonpark.bin"
 	.align 8192
 
 
@@ -418,7 +397,7 @@
 		.byte song_time_machine ;_________________________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________________________ Spike Set, Block Set
@@ -433,59 +412,9 @@
 	.align 8192
 
 
-; Data bank 13, total bank size: 8177 bytes
+; Data bank 13, total bank size: 7976 bytes
 	sprite_data_aftercatabath:	; Size: 5756
 		.incbin "EXPORTS/sprite/aftercatabath.bin"
-	sprite_data_goldenhaze:	; Size: 2421
-		.incbin "EXPORTS/sprite/goldenhaze.bin"
-	.align 8192
-
-
-; Data bank 14, total bank size: 8022 bytes
-	.export level_data_acropolis
-	level_data_acropolis:
-	; Header
-		.byte <sprite_data_acropolis ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_acropolis) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_acropolis >> 13) ;_________ Sprite data bank
-		.byte song_final_battle ;______________________ Song ID
-		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $00 ;____________________________________ Starting background color
-		.byte $00 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/acropolis.lz.bin" ; Size: 5638
-
-	sprite_data_icdx:	; Size: 2371
-		.incbin "EXPORTS/sprite/icdx.bin"
-	.align 8192
-
-
-; Data bank 15, total bank size: 8132 bytes
-	.export level_data_speedracer
-	level_data_speedracer:
-	; Header
-		.byte <sprite_data_speedracer ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_speedracer) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_speedracer >> 13) ;_________ Sprite data bank
-		.byte song_speed_racer ;________________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
-		.byte $0F ;_____________________________________ Starting background color
-		.byte $0F ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/speedracer.lz.bin" ; Size: 5628
-
 	.export level_data_shardscapes
 	level_data_shardscapes:
 	; Header
@@ -495,7 +424,7 @@
 		.byte song_slow_down ;___________________________ Song ID
 		.byte (1 << 4) | 4 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -505,15 +434,60 @@
 	; Level data
 		.incbin "EXPORTS/level/shardscapes.lz.bin" ; Size: 2207
 
-	.export level_data_windylandscape_4
-	level_data_windylandscape_4:
-	; Level data
-		.incbin "EXPORTS/level/windylandscape.lz.1.bin" ; Size: 271
-
 	.align 8192
 
 
-; Data bank 16, total bank size: 8144 bytes
+; Data bank 14, total bank size: 7972 bytes
+	.export level_data_acropolis
+	level_data_acropolis:
+	; Header
+		.byte <sprite_data_acropolis ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_acropolis) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_acropolis >> 13) ;_________ Sprite data bank
+		.byte song_final_battle ;______________________ Song ID
+		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $00 ;____________________________________ Starting background color
+		.byte $00 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/acropolis.lz.bin" ; Size: 5638
+
+	sprite_data_toeiiv2:	; Size: 2321
+		.incbin "EXPORTS/sprite/toeiiv2.bin"
+	.align 8192
+
+
+; Data bank 15, total bank size: 8012 bytes
+	.export level_data_speedracer
+	level_data_speedracer:
+	; Header
+		.byte <sprite_data_speedracer ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_speedracer) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_speedracer >> 13) ;_________ Sprite data bank
+		.byte song_speed_racer ;________________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
+		.byte $0F ;_____________________________________ Starting background color
+		.byte $0F ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/speedracer.lz.bin" ; Size: 5628
+
+	sprite_data_icdx:	; Size: 2371
+		.incbin "EXPORTS/sprite/icdx.bin"
+	.align 8192
+
+
+; Data bank 16, total bank size: 7979 bytes
 	.export level_data_silentclubstep
 	level_data_silentclubstep:
 	; Header
@@ -523,7 +497,7 @@
 		.byte song_clubstep ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -533,15 +507,12 @@
 	; Level data
 		.incbin "EXPORTS/level/silentclubstep.lz.bin" ; Size: 5545
 
-	.export level_data_skeletalshenanigans_1
-	level_data_skeletalshenanigans_1:
-	; Level data
-		.incbin "EXPORTS/level/skeletalshenanigans.lz.1.bin" ; Size: 2586
-
+	sprite_data_goldenhaze:	; Size: 2421
+		.incbin "EXPORTS/sprite/goldenhaze.bin"
 	.align 8192
 
 
-; Data bank 17, total bank size: 8046 bytes
+; Data bank 17, total bank size: 7986 bytes
 	.export level_data_demonpark
 	level_data_demonpark:
 	; Header
@@ -551,7 +522,7 @@
 		.byte song_time_machine ;______________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -561,19 +532,19 @@
 	; Level data
 		.incbin "EXPORTS/level/demonpark.lz.bin" ; Size: 4692
 
-	sprite_data_windylandscape:	; Size: 3341
-		.incbin "EXPORTS/sprite/windylandscape.bin"
+	sprite_data_heliopolis:	; Size: 3281
+		.incbin "EXPORTS/sprite/heliopolis.bin"
 	.align 8192
 
 
-; Data bank 18, total bank size: 7834 bytes
+; Data bank 18, total bank size: 7894 bytes
 	.export level_data_aftercatabath_6
 	level_data_aftercatabath_6:
 	; Level data
 		.incbin "EXPORTS/level/aftercatabath.lz.2.bin" ; Size: 4553
 
-	sprite_data_heliopolis:	; Size: 3281
-		.incbin "EXPORTS/sprite/heliopolis.bin"
+	sprite_data_windylandscape:	; Size: 3341
+		.incbin "EXPORTS/sprite/windylandscape.bin"
 	.align 8192
 
 
@@ -587,7 +558,7 @@
 		.byte song_supernova ;_____________________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -606,7 +577,7 @@
 		.byte song_endgame ;__________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -629,7 +600,7 @@
 		.byte song_haunted_woods ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -648,7 +619,7 @@
 		.byte song_flow ;_______________________________ Song ID
 		.byte (1 << 4) | 4 ;____________________________ Starting game mode and speed
 		.byte ($FF) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -671,7 +642,7 @@
 		.byte song_infinite_power ;__________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -689,7 +660,7 @@
 	.align 8192
 
 
-; Data bank 1C, total bank size: 8113 bytes
+; Data bank 1C, total bank size: 8098 bytes
 	.export level_data_wcropolix
 	level_data_wcropolix:
 	; Header
@@ -699,7 +670,7 @@
 		.byte song_fracture_wcropolix ;________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -709,12 +680,12 @@
 	; Level data
 		.incbin "EXPORTS/level/wcropolix.lz.bin" ; Size: 4154
 
-	sprite_data_infinitecircles:	; Size: 3946
-		.incbin "EXPORTS/sprite/infinitecircles.bin"
+	sprite_data_demonpyrophoric:	; Size: 3931
+		.incbin "EXPORTS/sprite/demonpyrophoric.bin"
 	.align 8192
 
 
-; Data bank 1D, total bank size: 8090 bytes
+; Data bank 1D, total bank size: 8105 bytes
 	.export level_data_denouement
 	level_data_denouement:
 	; Header
@@ -724,7 +695,7 @@
 		.byte song_glory ;______________________________ Song ID
 		.byte (4 << 4) | 6 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -734,56 +705,85 @@
 	; Level data
 		.incbin "EXPORTS/level/denouement.lz.bin" ; Size: 4146
 
-	sprite_data_demonpyrophoric:	; Size: 3931
-		.incbin "EXPORTS/sprite/demonpyrophoric.bin"
+	sprite_data_infinitecircles:	; Size: 3946
+		.incbin "EXPORTS/sprite/infinitecircles.bin"
 	.align 8192
 
 
-; Data bank 1E, total bank size: 8188 bytes
+; Data bank 1E, total bank size: 8053 bytes
 	sprite_data_demoncryogenic:	; Size: 3116
 		.incbin "EXPORTS/sprite/demoncryogenic.bin"
 	sprite_data_skeletalshenanigans:	; Size: 2751
 		.incbin "EXPORTS/sprite/skeletalshenanigans.bin"
-	sprite_data_toeiiv2:	; Size: 2321
-		.incbin "EXPORTS/sprite/toeiiv2.bin"
-	.align 8192
-
-
-; Data bank 1F, total bank size: 7403 bytes
-	sprite_data_speedracer:	; Size: 2646
-		.incbin "EXPORTS/sprite/speedracer.bin"
-	sprite_data_jawbreaker:	; Size: 2571
-		.incbin "EXPORTS/sprite/jawbreaker.bin"
 	sprite_data_azuronxolax:	; Size: 2186
 		.incbin "EXPORTS/sprite/azuronxolax.bin"
 	.align 8192
 
 
-; Data bank 20, total bank size: 8150 bytes
-	sprite_data_element111rg_with_secret_way:	; Size: 2086
-		.incbin "EXPORTS/sprite/element111rg_with_secret_way.bin"
-	sprite_data_styx:	; Size: 1781
-		.incbin "EXPORTS/sprite/styx.bin"
-	sprite_data_demonpark:	; Size: 1766
-		.incbin "EXPORTS/sprite/demonpark.bin"
-	sprite_data_gameover:	; Size: 1611
-		.incbin "EXPORTS/sprite/gameover.bin"
-	sprite_data_kratos:	; Size: 906
-		.incbin "EXPORTS/sprite/kratos.bin"
+; Data bank 1F, total bank size: 7803 bytes
+	sprite_data_speedracer:	; Size: 2646
+		.incbin "EXPORTS/sprite/speedracer.bin"
+	.export level_data_skeletalshenanigans_1
+	level_data_skeletalshenanigans_1:
+	; Level data
+		.incbin "EXPORTS/level/skeletalshenanigans.lz.1.bin" ; Size: 2586
+
+	sprite_data_jawbreaker:	; Size: 2571
+		.incbin "EXPORTS/sprite/jawbreaker.bin"
 	.align 8192
 
 
-; Data bank 21, total bank size: 4147 bytes
+; Data bank 20, total bank size: 7760 bytes
+	sprite_data_element111rg_with_secret_way:	; Size: 2086
+		.incbin "EXPORTS/sprite/element111rg_with_secret_way.bin"
+	.export level_data_explorers
+	level_data_explorers:
+	; Header
+		.byte <sprite_data_explorers ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_explorers) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_explorers >> 13) ;_________ Sprite data bank
+		.byte song_explorers ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $03 ;____________________________________ Starting background color
+		.byte $03 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/explorers.lz.bin" ; Size: 2029
+
+	sprite_data_silentclubstep:	; Size: 1851
+		.incbin "EXPORTS/sprite/silentclubstep.bin"
+	sprite_data_styx:	; Size: 1781
+		.incbin "EXPORTS/sprite/styx.bin"
+	.align 8192
+
+
+; Data bank 21, total bank size: 7451 bytes
 	sprite_data_slaughterhouse:	; Size: 1336
 		.incbin "EXPORTS/sprite/slaughterhouse.bin"
+	sprite_data_nullscapes:	; Size: 1101
+		.incbin "EXPORTS/sprite/nullscapes.bin"
+	sprite_data_wcropolix:	; Size: 1026
+		.incbin "EXPORTS/sprite/wcropolix.bin"
 	sprite_data_shardscapes:	; Size: 986
 		.incbin "EXPORTS/sprite/shardscapes.bin"
 	sprite_data_denouement:	; Size: 956
 		.incbin "EXPORTS/sprite/denouement.bin"
+	sprite_data_kratos:	; Size: 906
+		.incbin "EXPORTS/sprite/kratos.bin"
 	.export level_data_demonpyrophoric_2
 	level_data_demonpyrophoric_2:
 	; Level data
 		.incbin "EXPORTS/level/demonpyrophoric.lz.1.bin" ; Size: 869
+
+	.export level_data_windylandscape_4
+	level_data_windylandscape_4:
+	; Level data
+		.incbin "EXPORTS/level/windylandscape.lz.1.bin" ; Size: 271
 
 	.align 8192
 

--- a/LEVELS/include/lvlset_HUGE/all_level_data.s
+++ b/LEVELS/include/lvlset_HUGE/all_level_data.s
@@ -13,7 +13,7 @@
 		.byte song_magic_touch ;______________________ Song ID
 		.byte (1 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -36,7 +36,7 @@
 		.byte song_future_funk_pt1 ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -59,7 +59,7 @@
 		.byte song_pursuit ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -82,7 +82,7 @@
 		.byte song_atthespeedoflightfull ;_________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -123,7 +123,7 @@
 		.byte song_subtle_oddities ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -155,7 +155,7 @@
 		.byte song_pyrophoric_xl ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -178,7 +178,7 @@
 		.byte song_extraordinary_excitement ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________________________ Spike Set, Block Set
@@ -201,7 +201,7 @@
 		.byte song_the_angel ;___________________ Song ID
 		.byte (1 << 4) | 0 ;_____________________ Starting game mode and speed
 		.byte ($B0) ;____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSA ;_______ Spike Set, Block Set
@@ -233,7 +233,7 @@
 		.byte song_birdbrain ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($10) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________ Spike Set, Block Set
@@ -256,7 +256,7 @@
 		.byte song_cryogenic ;______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -279,7 +279,7 @@
 		.byte song_meltdown ;______________________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_________________ Spike Set, Block Set
@@ -302,7 +302,7 @@
 		.byte song_windfall ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -325,7 +325,7 @@
 		.byte song_tetris_remix_final ;_____________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -348,7 +348,7 @@
 		.byte song_carefree_victory_remix ;__________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________________ Spike Set, Block Set
@@ -371,7 +371,7 @@
 		.byte song_somewhere_in_a_forest ;______________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;______________________ Spike Set, Block Set
@@ -394,7 +394,7 @@
 		.byte song_slash_inferno ;_______________________________ Song ID
 		.byte (0 << 4) | 5 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________________ Spike Set, Block Set
@@ -417,7 +417,7 @@
 		.byte song_apoplexy ;___________________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -440,7 +440,7 @@
 		.byte song_sonic_blaster ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -472,7 +472,7 @@
 		.byte song_astronomical_expedition ;________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________________ Starting game mode and speed
 		.byte ($00) ;_______________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________________ Spike Set, Block Set
@@ -495,7 +495,7 @@
 		.byte song_new_dash_city ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -518,7 +518,7 @@
 		.byte song_try_this ;__________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -541,7 +541,7 @@
 		.byte song_snow ;_________________________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;________________________ Spike Set, Block Set
@@ -564,7 +564,7 @@
 		.byte song_cryogenic ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -593,7 +593,7 @@
 		.byte song_every_end_pt1 ;____________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;____________ Spike Set, Block Set
@@ -616,7 +616,7 @@
 		.byte song_careless ;__________________________ Song ID
 		.byte (1 << 4) | 1 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________ Spike Set, Block Set
@@ -639,7 +639,7 @@
 		.byte song_rainbow_tylenol ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;__________________ Spike Set, Block Set
@@ -662,7 +662,7 @@
 		.byte song_death_moon ;________________________ Song ID
 		.byte (3 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -675,7 +675,7 @@
 	.align 8192
 
 
-; Data bank 21, total bank size: 8192 bytes
+; Data bank 21, total bank size: 7981 bytes
 	.export level_data_sonicblaster
 	level_data_sonicblaster:
 	; Header
@@ -685,7 +685,7 @@
 		.byte song_sonic_blaster ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -695,12 +695,10 @@
 	; Level data
 		.incbin "EXPORTS/level/sonicblaster.lz.bin" ; Size: 7968
 
-	sprite_data_thecellar:	; Size: 211
-		.incbin "EXPORTS/sprite/thecellar.bin"
 	.align 8192
 
 
-; Data bank 22, total bank size: 8191 bytes
+; Data bank 22, total bank size: 7975 bytes
 	.export level_data_ninecircles
 	level_data_ninecircles:
 	; Header
@@ -710,7 +708,7 @@
 		.byte song_nine_circles ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -720,12 +718,10 @@
 	; Level data
 		.incbin "EXPORTS/level/ninecircles.lz.bin" ; Size: 7962
 
-	sprite_data_thetower:	; Size: 216
-		.incbin "EXPORTS/sprite/thetower.bin"
 	.align 8192
 
 
-; Data bank 23, total bank size: 8187 bytes
+; Data bank 23, total bank size: 8127 bytes
 	.export level_data_dash
 	level_data_dash:
 	; Header
@@ -735,7 +731,7 @@
 		.byte song_dash ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -745,15 +741,12 @@
 	; Level data
 		.incbin "EXPORTS/level/dash.lz.bin" ; Size: 7903
 
-	.export level_data_windylandscape_25
-	level_data_windylandscape_25:
-	; Level data
-		.incbin "EXPORTS/level/windylandscape.lz.1.bin" ; Size: 271
-
+	sprite_data_thecellar:	; Size: 211
+		.incbin "EXPORTS/sprite/thecellar.bin"
 	.align 8192
 
 
-; Data bank 24, total bank size: 8177 bytes
+; Data bank 24, total bank size: 8080 bytes
 	.export level_data_slaughterhouse
 	level_data_slaughterhouse:
 	; Header
@@ -763,7 +756,7 @@
 		.byte song_lost ;___________________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -773,40 +766,37 @@
 	; Level data
 		.incbin "EXPORTS/level/slaughterhouse.lz.bin" ; Size: 7851
 
-	.export level_data_thetripletrial
-	level_data_thetripletrial:
-	; Header
-		.byte <sprite_data_thetripletrial ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_thetripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_thetripletrial >> 13) ;_________ Sprite data bank
-		.byte song_dastardly ;______________________________ Song ID
-		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $00 ;_________________________________________ Starting background color
-		.byte $00 ;_________________________________________ Starting ground color
-		.byte 27 ;__________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/thetripletrial.lz.bin" ; Size: 300
-
+	sprite_data_thetower:	; Size: 216
+		.incbin "EXPORTS/sprite/thetower.bin"
 	.align 8192
 
 
-; Data bank 25, total bank size: 8190 bytes
+; Data bank 25, total bank size: 8095 bytes
 	sprite_data_cryogenic:	; Size: 7831
 		.incbin "EXPORTS/sprite/cryogenic.bin"
-	.export level_data_astronomicalexpedition_6
-	level_data_astronomicalexpedition_6:
+	.export level_data_doubletripletrial
+	level_data_doubletripletrial:
+	; Header
+		.byte <sprite_data_doubletripletrial ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_doubletripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_doubletripletrial >> 13) ;_________ Sprite data bank
+		.byte song_dastardly ;_________________________________ Song ID
+		.byte (4 << 4) | 0 ;___________________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
+		.byte $00 ;____________________________________________ Starting background color
+		.byte $00 ;____________________________________________ Starting ground color
+		.byte 27 ;_____________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/astronomicalexpedition.lz.3.bin" ; Size: 359
+		.incbin "EXPORTS/level/doubletripletrial.lz.bin" ; Size: 251
 
 	.align 8192
 
 
-; Data bank 26, total bank size: 8153 bytes
+; Data bank 26, total bank size: 8048 bytes
 	.export level_data_fingerdash
 	level_data_fingerdash:
 	; Header
@@ -816,7 +806,7 @@
 		.byte song_fingerdash ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -826,12 +816,15 @@
 	; Level data
 		.incbin "EXPORTS/level/fingerdash.lz.bin" ; Size: 7764
 
-	sprite_data_watertemple:	; Size: 376
-		.incbin "EXPORTS/sprite/watertemple.bin"
+	.export level_data_windylandscape_25
+	level_data_windylandscape_25:
+	; Level data
+		.incbin "EXPORTS/level/windylandscape.lz.1.bin" ; Size: 271
+
 	.align 8192
 
 
-; Data bank 27, total bank size: 8192 bytes
+; Data bank 27, total bank size: 8057 bytes
 	.export level_data_groundtospace
 	level_data_groundtospace:
 	; Header
@@ -841,7 +834,7 @@
 		.byte song_ground_to_space ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -851,23 +844,23 @@
 	; Level data
 		.incbin "EXPORTS/level/groundtospace.lz.bin" ; Size: 7763
 
-	sprite_data_foresttemple:	; Size: 416
-		.incbin "EXPORTS/sprite/foresttemple.bin"
+	sprite_data_thesecrethollow:	; Size: 281
+		.incbin "EXPORTS/sprite/thesecrethollow.bin"
 	.align 8192
 
 
-; Data bank 28, total bank size: 8112 bytes
+; Data bank 28, total bank size: 8082 bytes
 	.export level_data_heliopolis_31
 	level_data_heliopolis_31:
 	; Level data
 		.incbin "EXPORTS/level/heliopolis.lz.1.bin" ; Size: 7771
 
-	sprite_data_thesewers:	; Size: 341
-		.incbin "EXPORTS/sprite/thesewers.bin"
+	sprite_data_acropolis:	; Size: 311
+		.incbin "EXPORTS/sprite/acropolis.bin"
 	.align 8192
 
 
-; Data bank 29, total bank size: 7736 bytes
+; Data bank 29, total bank size: 8095 bytes
 	.export level_data_bloodbath
 	level_data_bloodbath:
 	; Header
@@ -877,7 +870,7 @@
 		.byte song_atthespeedoflight2 ;________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -887,10 +880,15 @@
 	; Level data
 		.incbin "EXPORTS/level/bloodbath.lz.bin" ; Size: 7723
 
+	.export level_data_astronomicalexpedition_6
+	level_data_astronomicalexpedition_6:
+	; Level data
+		.incbin "EXPORTS/level/astronomicalexpedition.lz.3.bin" ; Size: 359
+
 	.align 8192
 
 
-; Data bank 2A, total bank size: 8186 bytes
+; Data bank 2A, total bank size: 8126 bytes
 	.export level_data_rainingtacos
 	level_data_rainingtacos:
 	; Header
@@ -900,7 +898,7 @@
 		.byte song_raining_tacos ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($00) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -910,8 +908,8 @@
 	; Level data
 		.incbin "EXPORTS/level/rainingtacos.lz.bin" ; Size: 7647
 
-	sprite_data_madness:	; Size: 526
-		.incbin "EXPORTS/sprite/madness.bin"
+	sprite_data_chippe:	; Size: 466
+		.incbin "EXPORTS/sprite/chippe.bin"
 	.align 8192
 
 
@@ -925,7 +923,7 @@
 		.byte song_check_out ;____________________________ Song ID
 		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -935,18 +933,20 @@
 	; Level data
 		.incbin "EXPORTS/level/scarletsurge.lz.bin" ; Size: 7555
 
-	sprite_data_chippe:	; Size: 466
-		.incbin "EXPORTS/sprite/chippe.bin"
+	sprite_data_xmaschallenge:	; Size: 466
+		.incbin "EXPORTS/sprite/xmaschallenge.bin"
 	.align 8192
 
 
-; Data bank 2C, total bank size: 7531 bytes
+; Data bank 2C, total bank size: 8057 bytes
 	sprite_data_astronomicalexpedition:	; Size: 7531
 		.incbin "EXPORTS/sprite/astronomicalexpedition.bin"
+	sprite_data_madness:	; Size: 526
+		.incbin "EXPORTS/sprite/madness.bin"
 	.align 8192
 
 
-; Data bank 2D, total bank size: 7520 bytes
+; Data bank 2D, total bank size: 8091 bytes
 	.export level_data_pgclubstep
 	level_data_pgclubstep:
 	; Header
@@ -956,7 +956,7 @@
 		.byte song_clubstep ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -966,10 +966,12 @@
 	; Level data
 		.incbin "EXPORTS/level/pgclubstep.lz.bin" ; Size: 7507
 
+	sprite_data_nicktoons:	; Size: 571
+		.incbin "EXPORTS/sprite/nicktoons.bin"
 	.align 8192
 
 
-; Data bank 2E, total bank size: 8120 bytes
+; Data bank 2E, total bank size: 8101 bytes
 	.export level_data_kratos
 	level_data_kratos:
 	; Header
@@ -979,7 +981,7 @@
 		.byte song_kratos ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -989,12 +991,29 @@
 	; Level data
 		.incbin "EXPORTS/level/kratos.lz.bin" ; Size: 7391
 
-	sprite_data_movie:	; Size: 716
-		.incbin "EXPORTS/sprite/movie.bin"
+	.export level_data_luckydraw
+	level_data_luckydraw:
+	; Header
+		.byte <sprite_data_luckydraw ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_luckydraw) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_luckydraw >> 13) ;_________ Sprite data bank
+		.byte song_every_end_pt1 ;_____________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/luckydraw.lz.bin" ; Size: 684
+
 	.align 8192
 
 
-; Data bank 2F, total bank size: 8181 bytes
+; Data bank 2F, total bank size: 8081 bytes
 	.export level_data_goldenhaze
 	level_data_goldenhaze:
 	; Header
@@ -1004,7 +1023,7 @@
 		.byte song_golden_haze ;________________________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -1014,12 +1033,12 @@
 	; Level data
 		.incbin "EXPORTS/level/goldenhaze.lz.bin" ; Size: 7352
 
-	sprite_data_short_kings:	; Size: 816
-		.incbin "EXPORTS/sprite/short_kings.bin"
+	sprite_data_movie:	; Size: 716
+		.incbin "EXPORTS/sprite/movie.bin"
 	.align 8192
 
 
-; Data bank 30, total bank size: 8146 bytes
+; Data bank 30, total bank size: 8067 bytes
 	.export level_data_hexagonforce
 	level_data_hexagonforce:
 	; Header
@@ -1029,7 +1048,7 @@
 		.byte song_hexagon_force ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -1039,15 +1058,12 @@
 	; Level data
 		.incbin "EXPORTS/level/hexagonforce.lz.bin" ; Size: 7328
 
-	.export level_data_eon_24
-	level_data_eon_24:
-	; Level data
-		.incbin "EXPORTS/level/eon.lz.1.bin" ; Size: 805
-
+	sprite_data_trolledfix:	; Size: 726
+		.incbin "EXPORTS/sprite/trolledfix.bin"
 	.align 8192
 
 
-; Data bank 31, total bank size: 8169 bytes
+; Data bank 31, total bank size: 8114 bytes
 	.export level_data_chaozimpact
 	level_data_chaozimpact:
 	; Header
@@ -1057,7 +1073,7 @@
 		.byte song_chaoz_impact ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -1067,12 +1083,12 @@
 	; Level data
 		.incbin "EXPORTS/level/chaozimpact.lz.bin" ; Size: 7245
 
-	sprite_data_backontrack:	; Size: 911
-		.incbin "EXPORTS/sprite/backontrack.bin"
+	sprite_data_cantletgo:	; Size: 856
+		.incbin "EXPORTS/sprite/cantletgo.bin"
 	.align 8192
 
 
-; Data bank 32, total bank size: 8176 bytes
+; Data bank 32, total bank size: 8051 bytes
 	.export level_data_rotd
 	level_data_rotd:
 	; Header
@@ -1082,7 +1098,7 @@
 		.byte song_mario_kart_7__rainbow_road_remix ;___ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;______________ Spike Set, Block Set
@@ -1092,12 +1108,12 @@
 	; Level data
 		.incbin "EXPORTS/level/rotd.lz.bin" ; Size: 7177
 
-	sprite_data_shardscapes:	; Size: 986
-		.incbin "EXPORTS/sprite/shardscapes.bin"
+	sprite_data_retray:	; Size: 861
+		.incbin "EXPORTS/sprite/retray.bin"
 	.align 8192
 
 
-; Data bank 33, total bank size: 8186 bytes
+; Data bank 33, total bank size: 8051 bytes
 	.export level_data_icdx
 	level_data_icdx:
 	; Header
@@ -1107,7 +1123,7 @@
 		.byte song_clubstep ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -1117,12 +1133,12 @@
 	; Level data
 		.incbin "EXPORTS/level/icdx.lz.bin" ; Size: 7132
 
-	sprite_data_groundtoretray:	; Size: 1041
-		.incbin "EXPORTS/sprite/groundtoretray.bin"
+	sprite_data_kratos:	; Size: 906
+		.incbin "EXPORTS/sprite/kratos.bin"
 	.align 8192
 
 
-; Data bank 34, total bank size: 8191 bytes
+; Data bank 34, total bank size: 8156 bytes
 	.export level_data_ninecircleseasy
 	level_data_ninecircleseasy:
 	; Header
@@ -1132,7 +1148,7 @@
 		.byte song_nine_circles ;____________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -1142,8 +1158,8 @@
 	; Level data
 		.incbin "EXPORTS/level/ninecircleseasy.lz.bin" ; Size: 7077
 
-	sprite_data_shadowtemple:	; Size: 1101
-		.incbin "EXPORTS/sprite/shadowtemple.bin"
+	sprite_data_kappaclysm:	; Size: 1066
+		.incbin "EXPORTS/sprite/kappaclysm.bin"
 	.align 8192
 
 
@@ -1157,7 +1173,7 @@
 		.byte song_atthespeedoflightfull ;_____________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -1172,7 +1188,7 @@
 	.align 8192
 
 
-; Data bank 36, total bank size: 8192 bytes
+; Data bank 36, total bank size: 8177 bytes
 	.export level_data_endgame
 	level_data_endgame:
 	; Header
@@ -1182,7 +1198,7 @@
 		.byte song_endgame_full ;____________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;____________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;___________ Spike Set, Block Set
@@ -1192,12 +1208,12 @@
 	; Level data
 		.incbin "EXPORTS/level/endgame.lz.bin" ; Size: 7018
 
-	sprite_data_aprettyeasylevel:	; Size: 1161
-		.incbin "EXPORTS/sprite/aprettyeasylevel.bin"
+	sprite_data_baseafterbase:	; Size: 1146
+		.incbin "EXPORTS/sprite/baseafterbase.bin"
 	.align 8192
 
 
-; Data bank 37, total bank size: 8191 bytes
+; Data bank 37, total bank size: 8136 bytes
 	.export level_data_jawbreaker
 	level_data_jawbreaker:
 	; Header
@@ -1207,7 +1223,7 @@
 		.byte song_jawbreaker ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -1217,16 +1233,33 @@
 	; Level data
 		.incbin "EXPORTS/level/jawbreaker.lz.bin" ; Size: 6877
 
-	sprite_data_thetripletrial:	; Size: 1301
-		.incbin "EXPORTS/sprite/thetripletrial.bin"
+	sprite_data_jumper:	; Size: 1246
+		.incbin "EXPORTS/sprite/jumper.bin"
 	.align 8192
 
 
-; Data bank 38, total bank size: 8177 bytes
+; Data bank 38, total bank size: 8117 bytes
 	sprite_data_tetrix:	; Size: 6841
 		.incbin "EXPORTS/sprite/tetrix.bin"
-	sprite_data_slaughterhouse:	; Size: 1336
-		.incbin "EXPORTS/sprite/slaughterhouse.bin"
+	.export level_data_xmaschallenge
+	level_data_xmaschallenge:
+	; Header
+		.byte <sprite_data_xmaschallenge ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_xmaschallenge) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_xmaschallenge >> 13) ;_________ Sprite data bank
+		.byte song_snow ;__________________________________ Song ID
+		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
+		.byte $16 ;________________________________________ Starting background color
+		.byte $0F ;________________________________________ Starting ground color
+		.byte 27 ;_________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/xmaschallenge.lz.bin" ; Size: 1263
+
 	.align 8192
 
 
@@ -1240,7 +1273,7 @@
 		.byte song_fairydust ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -1268,7 +1301,7 @@
 		.byte song_atthespeedoflight3 ;________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -1278,12 +1311,12 @@
 	; Level data
 		.incbin "EXPORTS/level/aftermath.lz.bin" ; Size: 6783
 
-	sprite_data_bestautomaticlvl:	; Size: 1396
-		.incbin "EXPORTS/sprite/bestautomaticlvl.bin"
+	sprite_data_xx:	; Size: 1396
+		.incbin "EXPORTS/sprite/xx.bin"
 	.align 8192
 
 
-; Data bank 3B, total bank size: 8185 bytes
+; Data bank 3B, total bank size: 8169 bytes
 	.export level_data_invisiblelight
 	level_data_invisiblelight:
 	; Header
@@ -1293,7 +1326,7 @@
 		.byte song_blacklight ;_____________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -1303,29 +1336,12 @@
 	; Level data
 		.incbin "EXPORTS/level/invisiblelight.lz.bin" ; Size: 6760
 
-	.export level_data_backontrack
-	level_data_backontrack:
-	; Header
-		.byte <sprite_data_backontrack ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_backontrack) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_backontrack >> 13) ;_________ Sprite data bank
-		.byte song_back_on_track ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
-		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
-		.byte $14 ;______________________________________ Starting background color
-		.byte $14 ;______________________________________ Starting ground color
-		.byte 27 ;_______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/backontrack.lz.bin" ; Size: 1399
-
+	sprite_data_bestautomaticlvl:	; Size: 1396
+		.incbin "EXPORTS/sprite/bestautomaticlvl.bin"
 	.align 8192
 
 
-; Data bank 3C, total bank size: 8186 bytes
+; Data bank 3C, total bank size: 8176 bytes
 	.export level_data_azuronxolax
 	level_data_azuronxolax:
 	; Header
@@ -1335,7 +1351,7 @@
 		.byte song_endgame_full ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -1345,8 +1361,8 @@
 	; Level data
 		.incbin "EXPORTS/level/azuronxolax.lz.bin" ; Size: 6672
 
-	sprite_data_aftermath:	; Size: 1501
-		.incbin "EXPORTS/sprite/aftermath.bin"
+	sprite_data_fingerdash:	; Size: 1491
+		.incbin "EXPORTS/sprite/fingerdash.bin"
 	.align 8192
 
 
@@ -1360,7 +1376,7 @@
 		.byte song_toe_2 ;___________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________ Spike Set, Block Set
@@ -1393,7 +1409,7 @@
 		.byte song_endorphins ;____________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -1403,8 +1419,8 @@
 	; Level data
 		.incbin "EXPORTS/level/endorphinrush.lz.bin" ; Size: 6525
 
-	sprite_data_hexagonforce:	; Size: 1631
-		.incbin "EXPORTS/sprite/hexagonforce.bin"
+	sprite_data_offtomars:	; Size: 1631
+		.incbin "EXPORTS/sprite/offtomars.bin"
 	.align 8192
 
 
@@ -1418,7 +1434,7 @@
 		.byte song_thermodynamix ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -1428,12 +1444,12 @@
 	; Level data
 		.incbin "EXPORTS/level/thermodynamix.lz.bin" ; Size: 6524
 
-	sprite_data_offtomars:	; Size: 1631
-		.incbin "EXPORTS/sprite/offtomars.bin"
+	sprite_data_hexagonforce:	; Size: 1631
+		.incbin "EXPORTS/sprite/hexagonforce.bin"
 	.align 8192
 
 
-; Data bank 41, total bank size: 8184 bytes
+; Data bank 41, total bank size: 8144 bytes
 	.export level_data_dastardly
 	level_data_dastardly:
 	; Header
@@ -1453,12 +1469,12 @@
 	; Level data
 		.incbin "EXPORTS/level/dastardly.lz.bin" ; Size: 6470
 
-	sprite_data_everyend:	; Size: 1701
-		.incbin "EXPORTS/sprite/everyend.bin"
+	sprite_data_wintherace:	; Size: 1661
+		.incbin "EXPORTS/sprite/wintherace.bin"
 	.align 8192
 
 
-; Data bank 42, total bank size: 8187 bytes
+; Data bank 42, total bank size: 8137 bytes
 	.export level_data_clutterfunk2
 	level_data_clutterfunk2:
 	; Header
@@ -1468,7 +1484,7 @@
 		.byte song_clutterfunk_2 ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -1478,12 +1494,12 @@
 	; Level data
 		.incbin "EXPORTS/level/clutterfunk2.lz.bin" ; Size: 6453
 
-	sprite_data_thelightningroad:	; Size: 1721
-		.incbin "EXPORTS/sprite/thelightningroad.bin"
+	sprite_data_lostinthewoods:	; Size: 1671
+		.incbin "EXPORTS/sprite/lostinthewoods.bin"
 	.align 8192
 
 
-; Data bank 43, total bank size: 8164 bytes
+; Data bank 43, total bank size: 8148 bytes
 	.export level_data_fireaura
 	level_data_fireaura:
 	; Header
@@ -1493,7 +1509,7 @@
 		.byte song_fire_aura ;________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -1502,31 +1518,6 @@
 		.byte 27 ;____________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/fireaura.lz.bin" ; Size: 6435
-
-	sprite_data_greif:	; Size: 1716
-		.incbin "EXPORTS/sprite/greif.bin"
-	.align 8192
-
-
-; Data bank 44, total bank size: 8148 bytes
-	.export level_data_solarcircles
-	level_data_solarcircles:
-	; Header
-		.byte <sprite_data_solarcircles ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_solarcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_solarcircles >> 13) ;_________ Sprite data bank
-		.byte song_solar_wind ;___________________________ Song ID
-		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
-		.byte $0F ;_______________________________________ Starting background color
-		.byte $0F ;_______________________________________ Starting ground color
-		.byte 31 ;________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/solarcircles.lz.bin" ; Size: 6435
 
 	.export level_data_short_kings
 	level_data_short_kings:
@@ -1537,7 +1528,7 @@
 		.byte song_load ;________________________________ Song ID
 		.byte (3 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($00) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -1546,6 +1537,34 @@
 		.byte 27 ;_______________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/short_kings.lz.bin" ; Size: 1687
+
+	.align 8192
+
+
+; Data bank 44, total bank size: 8124 bytes
+	.export level_data_solarcircles
+	level_data_solarcircles:
+	; Header
+		.byte <sprite_data_solarcircles ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_solarcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_solarcircles >> 13) ;_________ Sprite data bank
+		.byte song_solar_wind ;___________________________ Song ID
+		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
+		.byte $0F ;_______________________________________ Starting background color
+		.byte $0F ;_______________________________________ Starting ground color
+		.byte 31 ;________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/solarcircles.lz.bin" ; Size: 6435
+
+	.export level_data_cryogenic_2
+	level_data_cryogenic_2:
+	; Level data
+		.incbin "EXPORTS/level/cryogenic.lz.1.bin" ; Size: 1676
 
 	.align 8192
 
@@ -1560,7 +1579,7 @@
 		.byte song_deadlocked ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -1575,7 +1594,7 @@
 	.align 8192
 
 
-; Data bank 46, total bank size: 8188 bytes
+; Data bank 46, total bank size: 8177 bytes
 	.export level_data_geometricaldominator
 	level_data_geometricaldominator:
 	; Header
@@ -1585,7 +1604,7 @@
 		.byte song_geometrical_dominator ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;________________________ Spike Set, Block Set
@@ -1595,17 +1614,131 @@
 	; Level data
 		.incbin "EXPORTS/level/geometricaldominator.lz.bin" ; Size: 6383
 
-	.export level_data_tetrix_12
-	level_data_tetrix_12:
+	sprite_data_cataclysm:	; Size: 1781
+		.incbin "EXPORTS/sprite/cataclysm.bin"
+	.align 8192
+
+
+; Data bank 47, total bank size: 8097 bytes
+	sprite_data_respitev2:	; Size: 6266
+		.incbin "EXPORTS/sprite/respitev2.bin"
+	.export level_data_bestautomaticlvl
+	level_data_bestautomaticlvl:
+	; Header
+		.byte <sprite_data_bestautomaticlvl ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_bestautomaticlvl) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_bestautomaticlvl >> 13) ;_________ Sprite data bank
+		.byte song_dry_out ;__________________________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;____________________ Spike Set, Block Set
+		.byte $16 ;___________________________________________ Starting background color
+		.byte $10 ;___________________________________________ Starting ground color
+		.byte 36 ;____________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/tetrix.lz.1.bin" ; Size: 1792
+		.incbin "EXPORTS/level/bestautomaticlvl.lz.bin" ; Size: 1818
 
 	.align 8192
 
 
-; Data bank 47, total bank size: 8181 bytes
-	sprite_data_respitev2:	; Size: 6266
-		.incbin "EXPORTS/sprite/respitev2.bin"
+; Data bank 48, total bank size: 8049 bytes
+	.export level_data_xx
+	level_data_xx:
+	; Header
+		.byte <sprite_data_xx ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_xx) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_xx >> 13) ;_________ Sprite data bank
+		.byte song_holography ;_________________ Song ID
+		.byte (1 << 4) | 0 ;____________________ Starting game mode and speed
+		.byte ($B0) ;___________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_____________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;_______ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESB << 4) | _BLOCKSB ;______ Spike Set, Block Set
+		.byte $0F ;_____________________________ Starting background color
+		.byte $0F ;_____________________________ Starting ground color
+		.byte 57 ;______________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/xx.lz.bin" ; Size: 6190
+
+	sprite_data_deadlocked:	; Size: 1846
+		.incbin "EXPORTS/sprite/deadlocked.bin"
+	.align 8192
+
+
+; Data bank 49, total bank size: 8026 bytes
+	sprite_data_rainbowtylenol:	; Size: 6171
+		.incbin "EXPORTS/sprite/rainbowtylenol.bin"
+	.export level_data_stereomadness
+	level_data_stereomadness:
+	; Header
+		.byte <sprite_data_stereomadness ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_stereomadness) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_stereomadness >> 13) ;_________ Sprite data bank
+		.byte song_stereo_madness ;________________________ Song ID
+		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
+		.byte $12 ;________________________________________ Starting background color
+		.byte $02 ;________________________________________ Starting ground color
+		.byte 27 ;_________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/stereomadness.lz.bin" ; Size: 1842
+
+	.align 8192
+
+
+; Data bank 4A, total bank size: 8044 bytes
+	.export level_data_lostinthewoods
+	level_data_lostinthewoods:
+	; Header
+		.byte <sprite_data_lostinthewoods ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_lostinthewoods) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_lostinthewoods >> 13) ;_________ Sprite data bank
+		.byte song_haunted_woods ;__________________________ Song ID
+		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $0F ;_________________________________________ Starting background color
+		.byte $0F ;_________________________________________ Starting ground color
+		.byte 47 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/lostinthewoods.lz.bin" ; Size: 6130
+
+	sprite_data_sunshine:	; Size: 1901
+		.incbin "EXPORTS/sprite/sunshine.bin"
+	.align 8192
+
+
+; Data bank 4B, total bank size: 8057 bytes
+	.export level_data_styx
+	level_data_styx:
+	; Header
+		.byte <sprite_data_styx ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_styx) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_styx >> 13) ;_________ Sprite data bank
+		.byte song_thermodynamix_acheron ;________ Song ID
+		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
+		.byte $11 ;_______________________________ Starting background color
+		.byte $11 ;_______________________________ Starting ground color
+		.byte 27 ;________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/styx.lz.bin" ; Size: 6129
+
 	.export level_data_jumper
 	level_data_jumper:
 	; Header
@@ -1615,7 +1748,7 @@
 		.byte song_jumper ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSC ;__________ Spike Set, Block Set
@@ -1628,124 +1761,7 @@
 	.align 8192
 
 
-; Data bank 48, total bank size: 8184 bytes
-	.export level_data_xx
-	level_data_xx:
-	; Header
-		.byte <sprite_data_xx ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_xx) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_xx >> 13) ;_________ Sprite data bank
-		.byte song_holography ;_________________ Song ID
-		.byte (1 << 4) | 0 ;____________________ Starting game mode and speed
-		.byte ($B0) ;___________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_____________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;_______ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESB << 4) | _BLOCKSB ;______ Spike Set, Block Set
-		.byte $0F ;_____________________________ Starting background color
-		.byte $0F ;_____________________________ Starting ground color
-		.byte 57 ;______________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/xx.lz.bin" ; Size: 6190
-
-	sprite_data_oceane:	; Size: 1981
-		.incbin "EXPORTS/sprite/oceane.bin"
-	.align 8192
-
-
-; Data bank 49, total bank size: 8192 bytes
-	sprite_data_rainbowtylenol:	; Size: 6171
-		.incbin "EXPORTS/sprite/rainbowtylenol.bin"
-	sprite_data_bloodbathbutno:	; Size: 2021
-		.incbin "EXPORTS/sprite/bloodbathbutno.bin"
-	.align 8192
-
-
-; Data bank 4A, total bank size: 8185 bytes
-	.export level_data_lostinthewoods
-	level_data_lostinthewoods:
-	; Header
-		.byte <sprite_data_lostinthewoods ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_lostinthewoods) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_lostinthewoods >> 13) ;_________ Sprite data bank
-		.byte song_haunted_woods ;__________________________ Song ID
-		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $0F ;_________________________________________ Starting background color
-		.byte $0F ;_________________________________________ Starting ground color
-		.byte 47 ;__________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/lostinthewoods.lz.bin" ; Size: 6130
-
-	.export level_data_explorers
-	level_data_explorers:
-	; Header
-		.byte <sprite_data_explorers ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_explorers) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_explorers >> 13) ;_________ Sprite data bank
-		.byte song_explorers ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $03 ;____________________________________ Starting background color
-		.byte $03 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/explorers.lz.bin" ; Size: 2029
-
-	.align 8192
-
-
-; Data bank 4B, total bank size: 8171 bytes
-	.export level_data_styx
-	level_data_styx:
-	; Header
-		.byte <sprite_data_styx ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_styx) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_styx >> 13) ;_________ Sprite data bank
-		.byte song_thermodynamix_acheron ;________ Song ID
-		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
-		.byte $11 ;_______________________________ Starting background color
-		.byte $11 ;_______________________________ Starting ground color
-		.byte 27 ;________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/styx.lz.bin" ; Size: 6129
-
-	.export level_data_baseafterbase
-	level_data_baseafterbase:
-	; Header
-		.byte <sprite_data_baseafterbase ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_baseafterbase) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_baseafterbase >> 13) ;_________ Sprite data bank
-		.byte song_base_after_base ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
-		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
-		.byte $11 ;________________________________________ Starting background color
-		.byte $11 ;________________________________________ Starting ground color
-		.byte 27 ;_________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/baseafterbase.lz.bin" ; Size: 2016
-
-	.align 8192
-
-
-; Data bank 4C, total bank size: 8191 bytes
+; Data bank 4C, total bank size: 8119 bytes
 	.export level_data_sunshine
 	level_data_sunshine:
 	; Header
@@ -1755,7 +1771,7 @@
 		.byte song_just_right ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -1765,29 +1781,12 @@
 	; Level data
 		.incbin "EXPORTS/level/sunshine.lz.bin" ; Size: 6125
 
-	.export level_data_cantletgo
-	level_data_cantletgo:
-	; Header
-		.byte <sprite_data_cantletgo ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_cantletgo) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_cantletgo >> 13) ;_________ Sprite data bank
-		.byte song_cant_let_go ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
-		.byte $14 ;____________________________________ Starting background color
-		.byte $04 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/cantletgo.lz.bin" ; Size: 2040
-
+	sprite_data_oceane:	; Size: 1981
+		.incbin "EXPORTS/sprite/oceane.bin"
 	.align 8192
 
 
-; Data bank 4D, total bank size: 8025 bytes
+; Data bank 4D, total bank size: 8145 bytes
 	.export level_data_dorabaebasic10
 	level_data_dorabaebasic10:
 	; Header
@@ -1797,7 +1796,7 @@
 		.byte song_infiltration ;___________________________ Song ID
 		.byte (2 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -1807,12 +1806,12 @@
 	; Level data
 		.incbin "EXPORTS/level/dorabaebasic10.lz.bin" ; Size: 6111
 
-	sprite_data_sunshine:	; Size: 1901
-		.incbin "EXPORTS/sprite/sunshine.bin"
+	sprite_data_bloodbathbutno:	; Size: 2021
+		.incbin "EXPORTS/sprite/bloodbathbutno.bin"
 	.align 8192
 
 
-; Data bank 4E, total bank size: 8188 bytes
+; Data bank 4E, total bank size: 8140 bytes
 	.export level_data_toe2
 	level_data_toe2:
 	; Header
@@ -1822,7 +1821,7 @@
 		.byte song_toe_2 ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
@@ -1832,29 +1831,12 @@
 	; Level data
 		.incbin "EXPORTS/level/toe2.lz.bin" ; Size: 6041
 
-	.export level_data_thesecrethollow
-	level_data_thesecrethollow:
-	; Header
-		.byte <sprite_data_thesecrethollow ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_thesecrethollow) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_thesecrethollow >> 13) ;_________ Sprite data bank
-		.byte song_scheming_weasel ;_________________________ Song ID
-		.byte (0 << 4) | 4 ;_________________________________ Starting game mode and speed
-		.byte ($40) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
-		.byte (1 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
-		.byte $03 ;__________________________________________ Starting background color
-		.byte $0F ;__________________________________________ Starting ground color
-		.byte 51 ;___________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/thesecrethollow.lz.bin" ; Size: 2121
-
+	sprite_data_fofii_fofii_fofii:	; Size: 2086
+		.incbin "EXPORTS/sprite/fofii_fofii_fofii.bin"
 	.align 8192
 
 
-; Data bank 4F, total bank size: 8181 bytes
+; Data bank 4F, total bank size: 8136 bytes
 	.export level_data_element111rg
 	level_data_element111rg:
 	; Header
@@ -1864,7 +1846,7 @@
 		.byte song_time_machine ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -1874,12 +1856,12 @@
 	; Level data
 		.incbin "EXPORTS/level/element111rg.lz.bin" ; Size: 6037
 
-	sprite_data_blastprocessing:	; Size: 2131
-		.incbin "EXPORTS/sprite/blastprocessing.bin"
+	sprite_data_cycles:	; Size: 2086
+		.incbin "EXPORTS/sprite/cycles.bin"
 	.align 8192
 
 
-; Data bank 50, total bank size: 8148 bytes
+; Data bank 50, total bank size: 8142 bytes
 	.export level_data_bloodbathbutno
 	level_data_bloodbathbutno:
 	; Header
@@ -1889,7 +1871,7 @@
 		.byte song_atthespeedoflight2 ;_____________________ Song ID
 		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -1899,6 +1881,14 @@
 	; Level data
 		.incbin "EXPORTS/level/bloodbathbutno.lz.bin" ; Size: 6023
 
+	sprite_data_silentcircles:	; Size: 2106
+		.incbin "EXPORTS/sprite/silentcircles.bin"
+	.align 8192
+
+
+; Data bank 51, total bank size: 8133 bytes
+	sprite_data_danceofviolins:	; Size: 6021
+		.incbin "EXPORTS/sprite/danceofviolins.bin"
 	.export level_data_leveleasy
 	level_data_leveleasy:
 	; Header
@@ -1908,7 +1898,7 @@
 		.byte song_stereo_madness ;____________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -1921,26 +1911,18 @@
 	.align 8192
 
 
-; Data bank 51, total bank size: 8127 bytes
-	sprite_data_danceofviolins:	; Size: 6021
-		.incbin "EXPORTS/sprite/danceofviolins.bin"
-	sprite_data_silentcircles:	; Size: 2106
-		.incbin "EXPORTS/sprite/silentcircles.bin"
-	.align 8192
-
-
-; Data bank 52, total bank size: 8109 bytes
+; Data bank 52, total bank size: 8129 bytes
 	.export level_data_newdashcity_10
 	level_data_newdashcity_10:
 	; Level data
 		.incbin "EXPORTS/level/newdashcity.lz.1.bin" ; Size: 6008
 
-	sprite_data_somewhereinaforest:	; Size: 2101
-		.incbin "EXPORTS/sprite/somewhereinaforest.bin"
+	sprite_data_problematic:	; Size: 2121
+		.incbin "EXPORTS/sprite/problematic.bin"
 	.align 8192
 
 
-; Data bank 53, total bank size: 8188 bytes
+; Data bank 53, total bank size: 8182 bytes
 	.export level_data_decode
 	level_data_decode:
 	; Header
@@ -1950,7 +1932,7 @@
 		.byte song_endgame_full ;___________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -1959,31 +1941,6 @@
 		.byte 27 ;__________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/decode.lz.bin" ; Size: 5869
-
-	sprite_data_lookatthislevel:	; Size: 2306
-		.incbin "EXPORTS/sprite/lookatthislevel.bin"
-	.align 8192
-
-
-; Data bank 54, total bank size: 8172 bytes
-	.export level_data_overawed
-	level_data_overawed:
-	; Header
-		.byte <sprite_data_overawed ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_overawed) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_overawed >> 13) ;_________ Sprite data bank
-		.byte song_deep_swim ;________________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSD ;____________ Spike Set, Block Set
-		.byte $0F ;___________________________________ Starting background color
-		.byte $0F ;___________________________________ Starting ground color
-		.byte 27 ;____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/overawed.lz.bin" ; Size: 5859
 
 	.export level_data_factorytime
 	level_data_factorytime:
@@ -1994,7 +1951,7 @@
 		.byte song_factory_time ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
@@ -2007,23 +1964,48 @@
 	.align 8192
 
 
-; Data bank 55, total bank size: 8152 bytes
+; Data bank 54, total bank size: 8178 bytes
+	.export level_data_overawed
+	level_data_overawed:
+	; Header
+		.byte <sprite_data_overawed ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_overawed) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_overawed >> 13) ;_________ Sprite data bank
+		.byte song_deep_swim ;________________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSD ;____________ Spike Set, Block Set
+		.byte $0F ;___________________________________ Starting background color
+		.byte $0F ;___________________________________ Starting ground color
+		.byte 27 ;____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/overawed.lz.bin" ; Size: 5859
+
+	sprite_data_lookatthislevel:	; Size: 2306
+		.incbin "EXPORTS/sprite/lookatthislevel.bin"
+	.align 8192
+
+
+; Data bank 55, total bank size: 8102 bytes
 	sprite_data_extraordinaryexcitement:	; Size: 5781
 		.incbin "EXPORTS/sprite/extraordinaryexcitement.bin"
-	sprite_data_icdx:	; Size: 2371
-		.incbin "EXPORTS/sprite/icdx.bin"
+	sprite_data_toeiiv2:	; Size: 2321
+		.incbin "EXPORTS/sprite/toeiiv2.bin"
 	.align 8192
 
 
-; Data bank 56, total bank size: 8187 bytes
+; Data bank 56, total bank size: 8077 bytes
 	sprite_data_aftercatabath:	; Size: 5756
 		.incbin "EXPORTS/sprite/aftercatabath.bin"
-	sprite_data_geometricaldominator:	; Size: 2431
-		.incbin "EXPORTS/sprite/geometricaldominator.bin"
+	sprite_data_timemachine:	; Size: 2321
+		.incbin "EXPORTS/sprite/timemachine.bin"
 	.align 8192
 
 
-; Data bank 57, total bank size: 8169 bytes
+; Data bank 57, total bank size: 8072 bytes
 	.export level_data_eighto
 	level_data_eighto:
 	; Header
@@ -2033,7 +2015,7 @@
 		.byte song_eighto ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;__________ Spike Set, Block Set
@@ -2042,56 +2024,6 @@
 		.byte 47 ;__________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/eighto.lz.bin" ; Size: 5730
-
-	sprite_data_deathmoon:	; Size: 2426
-		.incbin "EXPORTS/sprite/deathmoon.bin"
-	.align 8192
-
-
-; Data bank 58, total bank size: 8160 bytes
-	.export level_data_electrodynamix
-	level_data_electrodynamix:
-	; Header
-		.byte <sprite_data_electrodynamix ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_electrodynamix) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_electrodynamix >> 13) ;_________ Sprite data bank
-		.byte song_electrodynamix ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $19 ;_________________________________________ Starting background color
-		.byte $09 ;_________________________________________ Starting ground color
-		.byte 27 ;__________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/electrodynamix.lz.bin" ; Size: 5726
-
-	sprite_data_goldenhaze:	; Size: 2421
-		.incbin "EXPORTS/sprite/goldenhaze.bin"
-	.align 8192
-
-
-; Data bank 59, total bank size: 8055 bytes
-	.export level_data_hell
-	level_data_hell:
-	; Header
-		.byte <sprite_data_hell ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_hell) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_hell >> 13) ;_________ Sprite data bank
-		.byte song_accelerate ;___________________ Song ID
-		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;_________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
-		.byte $0F ;_______________________________ Starting background color
-		.byte $0F ;_______________________________ Starting ground color
-		.byte 36 ;________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/hell.lz.bin" ; Size: 5713
 
 	.export level_data_ninox
 	level_data_ninox:
@@ -2102,7 +2034,7 @@
 		.byte song_ninox ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_________ Spike Set, Block Set
@@ -2115,7 +2047,57 @@
 	.align 8192
 
 
-; Data bank 5A, total bank size: 8043 bytes
+; Data bank 58, total bank size: 8110 bytes
+	.export level_data_electrodynamix
+	level_data_electrodynamix:
+	; Header
+		.byte <sprite_data_electrodynamix ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_electrodynamix) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_electrodynamix >> 13) ;_________ Sprite data bank
+		.byte song_electrodynamix ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $19 ;_________________________________________ Starting background color
+		.byte $09 ;_________________________________________ Starting ground color
+		.byte 27 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/electrodynamix.lz.bin" ; Size: 5726
+
+	sprite_data_icdx:	; Size: 2371
+		.incbin "EXPORTS/sprite/icdx.bin"
+	.align 8192
+
+
+; Data bank 59, total bank size: 8147 bytes
+	.export level_data_hell
+	level_data_hell:
+	; Header
+		.byte <sprite_data_hell ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_hell) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_hell >> 13) ;_________ Sprite data bank
+		.byte song_accelerate ;___________________ Song ID
+		.byte (0 << 4) | 0 ;______________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;_________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________ Spike Set, Block Set
+		.byte $0F ;_______________________________ Starting background color
+		.byte $0F ;_______________________________ Starting ground color
+		.byte 36 ;________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/hell.lz.bin" ; Size: 5713
+
+	sprite_data_goldenhaze:	; Size: 2421
+		.incbin "EXPORTS/sprite/goldenhaze.bin"
+	.align 8192
+
+
+; Data bank 5A, total bank size: 8148 bytes
 	.export level_data_dorabaebasic7
 	level_data_dorabaebasic7:
 	; Header
@@ -2125,7 +2107,7 @@
 		.byte song_clownparty_remix ;______________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -2135,12 +2117,12 @@
 	; Level data
 		.incbin "EXPORTS/level/dorabaebasic7.lz.bin" ; Size: 5709
 
-	sprite_data_timemachine:	; Size: 2321
-		.incbin "EXPORTS/sprite/timemachine.bin"
+	sprite_data_deathmoon:	; Size: 2426
+		.incbin "EXPORTS/sprite/deathmoon.bin"
 	.align 8192
 
 
-; Data bank 5B, total bank size: 8175 bytes
+; Data bank 5B, total bank size: 8120 bytes
 	.export level_data_clubstep
 	level_data_clubstep:
 	; Header
@@ -2150,7 +2132,7 @@
 		.byte song_clubstep ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -2160,12 +2142,12 @@
 	; Level data
 		.incbin "EXPORTS/level/clubstep.lz.bin" ; Size: 5676
 
-	sprite_data_dash:	; Size: 2486
-		.incbin "EXPORTS/sprite/dash.bin"
+	sprite_data_geometricaldominator:	; Size: 2431
+		.incbin "EXPORTS/sprite/geometricaldominator.bin"
 	.align 8192
 
 
-; Data bank 5C, total bank size: 8173 bytes
+; Data bank 5C, total bank size: 8170 bytes
 	.export level_data_acropolis
 	level_data_acropolis:
 	; Header
@@ -2175,7 +2157,7 @@
 		.byte song_final_battle ;______________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -2184,6 +2166,48 @@
 		.byte 27 ;_____________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/acropolis.lz.bin" ; Size: 5638
+
+	.export level_data_nicktoons
+	level_data_nicktoons:
+	; Header
+		.byte <sprite_data_nicktoons ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_nicktoons) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_nicktoons >> 13) ;_________ Sprite data bank
+		.byte song_unity ;_____________________________ Song ID
+		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($00) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $28 ;____________________________________ Starting background color
+		.byte $27 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/nicktoons.lz.bin" ; Size: 2506
+
+	.align 8192
+
+
+; Data bank 5D, total bank size: 8163 bytes
+	.export level_data_speedracer
+	level_data_speedracer:
+	; Header
+		.byte <sprite_data_speedracer ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_speedracer) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_speedracer >> 13) ;_________ Sprite data bank
+		.byte song_chaoz_impact ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
+		.byte $0F ;_____________________________________ Starting background color
+		.byte $0F ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/speedracer.lz.bin" ; Size: 5628
 
 	.export level_data_thechallenge
 	level_data_thechallenge:
@@ -2194,7 +2218,7 @@
 		.byte song_the_challenge ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _EXTRASPRITES1 ;_________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -2207,35 +2231,7 @@
 	.align 8192
 
 
-; Data bank 5D, total bank size: 8192 bytes
-	.export level_data_speedracer
-	level_data_speedracer:
-	; Header
-		.byte <sprite_data_speedracer ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_speedracer) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_speedracer >> 13) ;_________ Sprite data bank
-		.byte song_chaoz_impact ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;_______________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
-		.byte $0F ;_____________________________________ Starting background color
-		.byte $0F ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/speedracer.lz.bin" ; Size: 5628
-
-	.export level_data_highlife_13
-	level_data_highlife_13:
-	; Level data
-		.incbin "EXPORTS/level/highlife.lz.1.bin" ; Size: 2551
-
-	.align 8192
-
-
-; Data bank 5E, total bank size: 8186 bytes
+; Data bank 5E, total bank size: 8169 bytes
 	.export level_data_silentclubstep
 	level_data_silentclubstep:
 	; Header
@@ -2245,7 +2241,7 @@
 		.byte song_clubstep ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -2255,49 +2251,32 @@
 	; Level data
 		.incbin "EXPORTS/level/silentclubstep.lz.bin" ; Size: 5545
 
-	.export level_data_everymadness
-	level_data_everymadness:
-	; Header
-		.byte <sprite_data_everymadness ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_everymadness) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_everymadness >> 13) ;_________ Sprite data bank
-		.byte song_every_madness ;________________________ Song ID
-		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_______________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;________________ Spike Set, Block Set
-		.byte $12 ;_______________________________________ Starting background color
-		.byte $02 ;_______________________________________ Starting ground color
-		.byte 27 ;________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/everymadness.lz.bin" ; Size: 2615
-
+	sprite_data_dorabaebasic4:	; Size: 2611
+		.incbin "EXPORTS/sprite/dorabaebasic4.bin"
 	.align 8192
 
 
-; Data bank 5F, total bank size: 8192 bytes
+; Data bank 5F, total bank size: 8162 bytes
 	sprite_data_clutterfunk2:	; Size: 5546
 		.incbin "EXPORTS/sprite/clutterfunk2.bin"
-	sprite_data_speedracer:	; Size: 2646
-		.incbin "EXPORTS/sprite/speedracer.bin"
+	sprite_data_xstep:	; Size: 2616
+		.incbin "EXPORTS/sprite/xstep.bin"
 	.align 8192
 
 
-; Data bank 60, total bank size: 8182 bytes
+; Data bank 60, total bank size: 8162 bytes
 	sprite_data_carefreevictory:	; Size: 5521
 		.incbin "EXPORTS/sprite/carefreevictory.bin"
-	sprite_data_bloodbath:	; Size: 2661
-		.incbin "EXPORTS/sprite/bloodbath.bin"
+	sprite_data_motion:	; Size: 2641
+		.incbin "EXPORTS/sprite/motion.bin"
 	.align 8192
 
 
-; Data bank 61, total bank size: 8157 bytes
+; Data bank 61, total bank size: 8152 bytes
 	sprite_data_rotd:	; Size: 5506
 		.incbin "EXPORTS/sprite/rotd.bin"
-	sprite_data_powertrip:	; Size: 2651
-		.incbin "EXPORTS/sprite/powertrip.bin"
+	sprite_data_speedracer:	; Size: 2646
+		.incbin "EXPORTS/sprite/speedracer.bin"
 	.align 8192
 
 
@@ -2311,7 +2290,7 @@
 		.byte song_endgame_full ;__________________________ Song ID
 		.byte (1 << 4) | 2 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -2330,7 +2309,7 @@
 		.byte song_golden_haze ;____________________ Song ID
 		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
@@ -2343,7 +2322,7 @@
 	.align 8192
 
 
-; Data bank 63, total bank size: 8160 bytes
+; Data bank 63, total bank size: 8150 bytes
 	.export level_data_fofii_fofii_fofii
 	level_data_fofii_fofii_fofii:
 	; Header
@@ -2353,7 +2332,7 @@
 		.byte song_meowstuff ;_________________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
@@ -2363,12 +2342,12 @@
 	; Level data
 		.incbin "EXPORTS/level/fofii_fofii_fofii.lz.bin" ; Size: 5431
 
-	sprite_data_decode:	; Size: 2716
-		.incbin "EXPORTS/sprite/decode.bin"
+	sprite_data_hi:	; Size: 2706
+		.incbin "EXPORTS/sprite/hi.bin"
 	.align 8192
 
 
-; Data bank 64, total bank size: 8189 bytes
+; Data bank 64, total bank size: 8154 bytes
 	.export level_data_revolution
 	level_data_revolution:
 	; Header
@@ -2378,7 +2357,7 @@
 		.byte song_infernoplex ;________________________ Song ID
 		.byte (3 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -2388,8 +2367,8 @@
 	; Level data
 		.incbin "EXPORTS/level/revolution.lz.bin" ; Size: 5425
 
-	sprite_data_skeletalshenanigans:	; Size: 2751
-		.incbin "EXPORTS/sprite/skeletalshenanigans.bin"
+	sprite_data_decode:	; Size: 2716
+		.incbin "EXPORTS/sprite/decode.bin"
 	.align 8192
 
 
@@ -2403,7 +2382,7 @@
 		.byte song_cosmic_dolphin ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($00) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSD ;_________________ Spike Set, Block Set
@@ -2413,12 +2392,12 @@
 	; Level data
 		.incbin "EXPORTS/level/cosmicdolphin.lz.bin" ; Size: 5392
 
-	sprite_data_clubstep:	; Size: 2786
-		.incbin "EXPORTS/sprite/clubstep.bin"
+	sprite_data_fairydust:	; Size: 2786
+		.incbin "EXPORTS/sprite/fairydust.bin"
 	.align 8192
 
 
-; Data bank 66, total bank size: 8176 bytes
+; Data bank 66, total bank size: 8136 bytes
 	.export level_data_danceofviolins
 	level_data_danceofviolins:
 	; Header
@@ -2428,7 +2407,7 @@
 		.byte song_dance_of_the_violins ;___________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -2438,8 +2417,8 @@
 	; Level data
 		.incbin "EXPORTS/level/danceofviolins.lz.bin" ; Size: 5312
 
-	sprite_data_rainbowdust:	; Size: 2851
-		.incbin "EXPORTS/sprite/rainbowdust.bin"
+	sprite_data_tinytunes:	; Size: 2811
+		.incbin "EXPORTS/sprite/tinytunes.bin"
 	.align 8192
 
 
@@ -2453,7 +2432,7 @@
 		.byte song_blast_processing ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -2468,7 +2447,7 @@
 	.align 8192
 
 
-; Data bank 68, total bank size: 8180 bytes
+; Data bank 68, total bank size: 8140 bytes
 	.export level_data_deadlyclubstep
 	level_data_deadlyclubstep:
 	; Header
@@ -2478,7 +2457,7 @@
 		.byte song_clubstep ;_______________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
@@ -2488,33 +2467,16 @@
 	; Level data
 		.incbin "EXPORTS/level/deadlyclubstep.lz.bin" ; Size: 5276
 
-	sprite_data_toe2:	; Size: 2891
-		.incbin "EXPORTS/sprite/toe2.bin"
+	sprite_data_rainbowdust:	; Size: 2851
+		.incbin "EXPORTS/sprite/rainbowdust.bin"
 	.align 8192
 
 
-; Data bank 69, total bank size: 8143 bytes
+; Data bank 69, total bank size: 8117 bytes
 	sprite_data_scarletsurge:	; Size: 5226
 		.incbin "EXPORTS/sprite/scarletsurge.bin"
-	.export level_data_oceane
-	level_data_oceane:
-	; Header
-		.byte <sprite_data_oceane ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_oceane) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_oceane >> 13) ;_________ Sprite data bank
-		.byte song_kesobomb ;_______________________ Song ID
-		.byte (2 << 4) | 0 ;________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;___________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
-		.byte $0F ;_________________________________ Starting background color
-		.byte $0F ;_________________________________ Starting ground color
-		.byte 27 ;__________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/oceane.lz.bin" ; Size: 2904
-
+	sprite_data_toe2:	; Size: 2891
+		.incbin "EXPORTS/sprite/toe2.bin"
 	.align 8192
 
 
@@ -2528,7 +2490,7 @@
 		.byte song_stalemate ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
@@ -2543,7 +2505,7 @@
 	.align 8192
 
 
-; Data bank 6B, total bank size: 8015 bytes
+; Data bank 6B, total bank size: 8121 bytes
 	.export level_data_generationretro
 	level_data_generationretro:
 	; Header
@@ -2553,7 +2515,7 @@
 		.byte song_glitch_gremlin ;__________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _EXTRASPRITES1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -2563,12 +2525,29 @@
 	; Level data
 		.incbin "EXPORTS/level/generationretro.lz.bin" ; Size: 5191
 
-	sprite_data_tinytunes:	; Size: 2811
-		.incbin "EXPORTS/sprite/tinytunes.bin"
+	.export level_data_oceane
+	level_data_oceane:
+	; Header
+		.byte <sprite_data_oceane ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_oceane) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_oceane >> 13) ;_________ Sprite data bank
+		.byte song_kesobomb ;_______________________ Song ID
+		.byte (2 << 4) | 0 ;________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;___________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________ Spike Set, Block Set
+		.byte $0F ;_________________________________ Starting background color
+		.byte $0F ;_________________________________ Starting ground color
+		.byte 27 ;__________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/oceane.lz.bin" ; Size: 2904
+
 	.align 8192
 
 
-; Data bank 6C, total bank size: 8192 bytes
+; Data bank 6C, total bank size: 8147 bytes
 	.export level_data_kappaclysm
 	level_data_kappaclysm:
 	; Header
@@ -2578,7 +2557,7 @@
 		.byte song_atthespeedoflightfull ;______________ Song ID
 		.byte (1 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -2588,31 +2567,31 @@
 	; Level data
 		.incbin "EXPORTS/level/kappaclysm.lz.bin" ; Size: 5063
 
-	sprite_data_demoncryogenic:	; Size: 3116
-		.incbin "EXPORTS/sprite/demoncryogenic.bin"
-	.align 8192
-
-
-; Data bank 6D, total bank size: 8152 bytes
-	.export level_data_carefreevictory_7
-	level_data_carefreevictory_7:
-	; Level data
-		.incbin "EXPORTS/level/carefreevictory.lz.1.bin" ; Size: 5066
-
-	sprite_data_thermodynamix:	; Size: 3086
-		.incbin "EXPORTS/sprite/thermodynamix.bin"
-	.align 8192
-
-
-; Data bank 6E, total bank size: 8137 bytes
-	sprite_data_newdashcity:	; Size: 5066
-		.incbin "EXPORTS/sprite/newdashcity.bin"
 	sprite_data_chaozimpact:	; Size: 3071
 		.incbin "EXPORTS/sprite/chaozimpact.bin"
 	.align 8192
 
 
-; Data bank 6F, total bank size: 8167 bytes
+; Data bank 6D, total bank size: 8182 bytes
+	.export level_data_carefreevictory_7
+	level_data_carefreevictory_7:
+	; Level data
+		.incbin "EXPORTS/level/carefreevictory.lz.1.bin" ; Size: 5066
+
+	sprite_data_demoncryogenic:	; Size: 3116
+		.incbin "EXPORTS/sprite/demoncryogenic.bin"
+	.align 8192
+
+
+; Data bank 6E, total bank size: 8152 bytes
+	sprite_data_newdashcity:	; Size: 5066
+		.incbin "EXPORTS/sprite/newdashcity.bin"
+	sprite_data_thermodynamix:	; Size: 3086
+		.incbin "EXPORTS/sprite/thermodynamix.bin"
+	.align 8192
+
+
+; Data bank 6F, total bank size: 8095 bytes
 	.export level_data_problematic
 	level_data_problematic:
 	; Header
@@ -2622,7 +2601,7 @@
 		.byte song_problematic ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -2632,20 +2611,54 @@
 	; Level data
 		.incbin "EXPORTS/level/problematic.lz.bin" ; Size: 4873
 
-	sprite_data_heliopolis:	; Size: 3281
-		.incbin "EXPORTS/sprite/heliopolis.bin"
+	.export level_data_groundtoretray
+	level_data_groundtoretray:
+	; Header
+		.byte <sprite_data_groundtoretray ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_groundtoretray) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_groundtoretray >> 13) ;_________ Sprite data bank
+		.byte song_ground_to_retray ;_______________________ Song ID
+		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $03 ;_________________________________________ Starting background color
+		.byte $00 ;_________________________________________ Starting ground color
+		.byte 27 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/groundtoretray.lz.bin" ; Size: 3196
+
 	.align 8192
 
 
-; Data bank 70, total bank size: 8177 bytes
+; Data bank 70, total bank size: 8135 bytes
 	sprite_data_highlife:	; Size: 4861
 		.incbin "EXPORTS/sprite/highlife.bin"
-	sprite_data_rainingtacos:	; Size: 3316
-		.incbin "EXPORTS/sprite/rainingtacos.bin"
+	.export level_data_funnygameholiday
+	level_data_funnygameholiday:
+	; Header
+		.byte <sprite_data_funnygameholiday ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_funnygameholiday) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_funnygameholiday >> 13) ;_________ Sprite data bank
+		.byte song_stereo_madness ;___________________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;____________________ Spike Set, Block Set
+		.byte $0F ;___________________________________________ Starting background color
+		.byte $0F ;___________________________________________ Starting ground color
+		.byte 27 ;____________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/funnygameholiday.lz.bin" ; Size: 3261
+
 	.align 8192
 
 
-; Data bank 71, total bank size: 8170 bytes
+; Data bank 71, total bank size: 8110 bytes
 	.export level_data_clutterfunk
 	level_data_clutterfunk:
 	; Header
@@ -2655,7 +2668,7 @@
 		.byte song_clutterfunk ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -2665,12 +2678,12 @@
 	; Level data
 		.incbin "EXPORTS/level/clutterfunk.lz.bin" ; Size: 4816
 
-	sprite_data_windylandscape:	; Size: 3341
-		.incbin "EXPORTS/sprite/windylandscape.bin"
+	sprite_data_heliopolis:	; Size: 3281
+		.incbin "EXPORTS/sprite/heliopolis.bin"
 	.align 8192
 
 
-; Data bank 72, total bank size: 8140 bytes
+; Data bank 72, total bank size: 8138 bytes
 	.export level_data_hi
 	level_data_hi:
 	; Header
@@ -2680,7 +2693,7 @@
 		.byte song_miami_hotline_vol_3 ;________ Song ID
 		.byte (1 << 4) | 0 ;____________________ Starting game mode and speed
 		.byte ($B0) ;___________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;______ Spike Set, Block Set
@@ -2689,6 +2702,31 @@
 		.byte 40 ;______________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/hi.lz.bin" ; Size: 4814
+
+	sprite_data_supercycles:	; Size: 3311
+		.incbin "EXPORTS/sprite/supercycles.bin"
+	.align 8192
+
+
+; Data bank 73, total bank size: 8123 bytes
+	.export level_data_tinytunes
+	level_data_tinytunes:
+	; Header
+		.byte <sprite_data_tinytunes ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_tinytunes) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_tinytunes >> 13) ;_________ Sprite data bank
+		.byte song_tiny_tunes ;________________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/tinytunes.lz.bin" ; Size: 4797
 
 	.export level_data_dorabaebasic4
 	level_data_dorabaebasic4:
@@ -2699,7 +2737,7 @@
 		.byte song_electrodynamix ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -2712,32 +2750,7 @@
 	.align 8192
 
 
-; Data bank 73, total bank size: 8191 bytes
-	.export level_data_tinytunes
-	level_data_tinytunes:
-	; Header
-		.byte <sprite_data_tinytunes ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_tinytunes) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_tinytunes >> 13) ;_________ Sprite data bank
-		.byte song_tiny_tunes ;________________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/tinytunes.lz.bin" ; Size: 4797
-
-	sprite_data_ajollyretrochristmas:	; Size: 3381
-		.incbin "EXPORTS/sprite/ajollyretrochristmas.bin"
-	.align 8192
-
-
-; Data bank 74, total bank size: 8185 bytes
+; Data bank 74, total bank size: 8112 bytes
 	.export level_data_chromaticexpedition
 	level_data_chromaticexpedition:
 	; Header
@@ -2747,7 +2760,7 @@
 		.byte song_somewhere_in_a_forest ;_______________________ Song ID
 		.byte (0 << 4) | 3 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________________ Spike Set, Block Set
@@ -2756,6 +2769,61 @@
 		.byte 27 ;_______________________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/chromaticexpedition.lz.bin" ; Size: 4783
+
+	sprite_data_rainingtacos:	; Size: 3316
+		.incbin "EXPORTS/sprite/rainingtacos.bin"
+	.align 8192
+
+
+; Data bank 75, total bank size: 8099 bytes
+	.export level_data_everyend_30
+	level_data_everyend_30:
+	; Level data
+		.incbin "EXPORTS/level/everyend.lz.2.bin" ; Size: 4758
+
+	sprite_data_windylandscape:	; Size: 3341
+		.incbin "EXPORTS/sprite/windylandscape.bin"
+	.align 8192
+
+
+; Data bank 76, total bank size: 8114 bytes
+	sprite_data_pyrophoric:	; Size: 4736
+		.incbin "EXPORTS/sprite/pyrophoric.bin"
+	.export level_data_deathmoon_15
+	level_data_deathmoon_15:
+	; Level data
+		.incbin "EXPORTS/level/deathmoon.lz.1.bin" ; Size: 3378
+
+	.align 8192
+
+
+; Data bank 77, total bank size: 8087 bytes
+	sprite_data_sonicwave:	; Size: 4706
+		.incbin "EXPORTS/sprite/sonicwave.bin"
+	sprite_data_ajollyretrochristmas:	; Size: 3381
+		.incbin "EXPORTS/sprite/ajollyretrochristmas.bin"
+	.align 8192
+
+
+; Data bank 78, total bank size: 8094 bytes
+	.export level_data_demonpark
+	level_data_demonpark:
+	; Header
+		.byte <sprite_data_demonpark ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_demonpark) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_demonpark >> 13) ;_________ Sprite data bank
+		.byte song_time_machine ;______________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESC << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
+		.byte $16 ;____________________________________ Starting background color
+		.byte $06 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/demonpark.lz.bin" ; Size: 4692
 
 	.export level_data_supercycles
 	level_data_supercycles:
@@ -2766,7 +2834,7 @@
 		.byte song_cycles ;______________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -2779,84 +2847,7 @@
 	.align 8192
 
 
-; Data bank 75, total bank size: 8136 bytes
-	.export level_data_everyend_30
-	level_data_everyend_30:
-	; Level data
-		.incbin "EXPORTS/level/everyend.lz.2.bin" ; Size: 4758
-
-	.export level_data_deathmoon_15
-	level_data_deathmoon_15:
-	; Level data
-		.incbin "EXPORTS/level/deathmoon.lz.1.bin" ; Size: 3378
-
-	.align 8192
-
-
-; Data bank 76, total bank size: 8192 bytes
-	sprite_data_pyrophoric:	; Size: 4736
-		.incbin "EXPORTS/sprite/pyrophoric.bin"
-	sprite_data_dorabaebasic8:	; Size: 3456
-		.incbin "EXPORTS/sprite/dorabaebasic8.bin"
-	.align 8192
-
-
-; Data bank 77, total bank size: 8017 bytes
-	sprite_data_sonicwave:	; Size: 4706
-		.incbin "EXPORTS/sprite/sonicwave.bin"
-	sprite_data_supercycles:	; Size: 3311
-		.incbin "EXPORTS/sprite/supercycles.bin"
-	.align 8192
-
-
-; Data bank 78, total bank size: 8165 bytes
-	.export level_data_demonpark
-	level_data_demonpark:
-	; Header
-		.byte <sprite_data_demonpark ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_demonpark) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_demonpark >> 13) ;_________ Sprite data bank
-		.byte song_time_machine ;______________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESC << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
-		.byte $16 ;____________________________________ Starting background color
-		.byte $06 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/demonpark.lz.bin" ; Size: 4692
-
-	.export level_data_funnygameholiday
-	level_data_funnygameholiday:
-	; Header
-		.byte <sprite_data_funnygameholiday ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_funnygameholiday) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_funnygameholiday >> 13) ;_________ Sprite data bank
-		.byte song_stereo_madness ;___________________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;____________________ Spike Set, Block Set
-		.byte $0F ;___________________________________________ Starting background color
-		.byte $0F ;___________________________________________ Starting ground color
-		.byte 27 ;____________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/funnygameholiday.lz.bin" ; Size: 3261
-
-	.export level_data_motion_16
-	level_data_motion_16:
-	; Level data
-		.incbin "EXPORTS/level/motion.lz.1.bin" ; Size: 186
-
-	.align 8192
-
-
-; Data bank 79, total bank size: 8177 bytes
+; Data bank 79, total bank size: 8155 bytes
 	.export level_data_akrile
 	level_data_akrile:
 	; Header
@@ -2866,7 +2857,7 @@
 		.byte song_the_explorer ;___________________ Song ID
 		.byte (1 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
@@ -2875,6 +2866,17 @@
 		.byte 27 ;__________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/akrile.lz.bin" ; Size: 4626
+
+	sprite_data_sonicblaster:	; Size: 3516
+		.incbin "EXPORTS/sprite/sonicblaster.bin"
+	.align 8192
+
+
+; Data bank 7A, total bank size: 8149 bytes
+	.export level_data_extraordinaryexcitement_14
+	level_data_extraordinaryexcitement_14:
+	; Level data
+		.incbin "EXPORTS/level/extraordinaryexcitement.lz.1.bin" ; Size: 4611
 
 	.export level_data_sonar
 	level_data_sonar:
@@ -2885,7 +2887,7 @@
 		.byte song_stereo_madness_2 ;______________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -2898,18 +2900,7 @@
 	.align 8192
 
 
-; Data bank 7A, total bank size: 8177 bytes
-	.export level_data_extraordinaryexcitement_14
-	level_data_extraordinaryexcitement_14:
-	; Level data
-		.incbin "EXPORTS/level/extraordinaryexcitement.lz.1.bin" ; Size: 4611
-
-	sprite_data_electrodynamix:	; Size: 3566
-		.incbin "EXPORTS/sprite/electrodynamix.bin"
-	.align 8192
-
-
-; Data bank 7B, total bank size: 8107 bytes
+; Data bank 7B, total bank size: 8157 bytes
 	.export level_data_rainbowdust
 	level_data_rainbowdust:
 	; Header
@@ -2919,7 +2910,7 @@
 		.byte song_chaozfantasy ;________________________ Song ID
 		.byte (1 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -2929,8 +2920,8 @@
 	; Level data
 		.incbin "EXPORTS/level/rainbowdust.lz.bin" ; Size: 4578
 
-	sprite_data_sonicblaster:	; Size: 3516
-		.incbin "EXPORTS/sprite/sonicblaster.bin"
+	sprite_data_electrodynamix:	; Size: 3566
+		.incbin "EXPORTS/sprite/electrodynamix.bin"
 	.align 8192
 
 
@@ -2957,7 +2948,7 @@
 		.byte song_against_the_odds_redux ;___________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;____________________ Spike Set, Block Set
@@ -2980,7 +2971,7 @@
 		.byte song_electroman_adventures ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________________ Spike Set, Block Set
@@ -2999,7 +2990,7 @@
 		.byte song_endgame_full ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSB ;____________ Spike Set, Block Set
@@ -3012,7 +3003,7 @@
 	.align 8192
 
 
-; Data bank 7F, total bank size: 8187 bytes
+; Data bank 7F, total bank size: 8171 bytes
 	.export level_data_storymadness
 	level_data_storymadness:
 	; Header
@@ -3022,7 +3013,7 @@
 		.byte song_stereo_madness ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;________________ Spike Set, Block Set
@@ -3031,6 +3022,34 @@
 		.byte 27 ;________________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/storymadness.lz.bin" ; Size: 4474
+
+	.export level_data_rainbowtylenol_8
+	level_data_rainbowtylenol_8:
+	; Level data
+		.incbin "EXPORTS/level/rainbowtylenol.lz.1.bin" ; Size: 3684
+
+	.align 8192
+
+
+; Data bank 80, total bank size: 8161 bytes
+	.export level_data_silentcircles
+	level_data_silentcircles:
+	; Header
+		.byte <sprite_data_silentcircles ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_silentcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_silentcircles >> 13) ;_________ Sprite data bank
+		.byte song_supernova ;_____________________________ Song ID
+		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
+		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
+		.byte $02 ;________________________________________ Starting background color
+		.byte $02 ;________________________________________ Starting ground color
+		.byte 30 ;_________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/silentcircles.lz.bin" ; Size: 4448
 
 	.export level_data_dreamer
 	level_data_dreamer:
@@ -3041,7 +3060,7 @@
 		.byte song_midnight ;________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________ Spike Set, Block Set
@@ -3054,46 +3073,35 @@
 	.align 8192
 
 
-; Data bank 80, total bank size: 8145 bytes
-	.export level_data_silentcircles
-	level_data_silentcircles:
-	; Header
-		.byte <sprite_data_silentcircles ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_silentcircles) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_silentcircles >> 13) ;_________ Sprite data bank
-		.byte song_supernova ;_____________________________ Song ID
-		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
-		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;__________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESC << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
-		.byte $02 ;________________________________________ Starting background color
-		.byte $02 ;________________________________________ Starting ground color
-		.byte 30 ;_________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/silentcircles.lz.bin" ; Size: 4448
-
-	.export level_data_rainbowtylenol_8
-	level_data_rainbowtylenol_8:
-	; Level data
-		.incbin "EXPORTS/level/rainbowtylenol.lz.1.bin" ; Size: 3684
-
-	.align 8192
-
-
-; Data bank 81, total bank size: 8190 bytes
+; Data bank 81, total bank size: 8189 bytes
 	.export level_data_ajollyretrochristmas_1
 	level_data_ajollyretrochristmas_1:
 	; Level data
 		.incbin "EXPORTS/level/ajollyretrochristmas.lz.1.bin" ; Size: 4439
 
-	sprite_data_dorabaebasic7:	; Size: 3751
-		.incbin "EXPORTS/sprite/dorabaebasic7.bin"
+	.export level_data_illusion
+	level_data_illusion:
+	; Header
+		.byte <sprite_data_illusion ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_illusion) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_illusion >> 13) ;_________ Sprite data bank
+		.byte song_operation_evolution ;______________ Song ID
+		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
+		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
+		.byte $0F ;___________________________________ Starting background color
+		.byte $0F ;___________________________________ Starting ground color
+		.byte 57 ;____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/illusion.lz.bin" ; Size: 3737
+
 	.align 8192
 
 
-; Data bank 82, total bank size: 8191 bytes
+; Data bank 82, total bank size: 8169 bytes
 	.export level_data_xstep
 	level_data_xstep:
 	; Header
@@ -3103,7 +3111,7 @@
 		.byte song_xstep ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;______________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_________ Spike Set, Block Set
@@ -3113,11 +3121,8 @@
 	; Level data
 		.incbin "EXPORTS/level/xstep.lz.bin" ; Size: 4405
 
-	.export level_data_sonicwave_26
-	level_data_sonicwave_26:
-	; Level data
-		.incbin "EXPORTS/level/sonicwave.lz.1.bin" ; Size: 3773
-
+	sprite_data_dorabaebasic7:	; Size: 3751
+		.incbin "EXPORTS/sprite/dorabaebasic7.bin"
 	.align 8192
 
 
@@ -3131,7 +3136,7 @@
 		.byte song_haunted_woods ;________________________ Song ID
 		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -3150,7 +3155,7 @@
 		.byte song_flow ;_______________________________ Song ID
 		.byte (1 << 4) | 4 ;____________________________ Starting game mode and speed
 		.byte ($FF) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -3163,32 +3168,18 @@
 	.align 8192
 
 
-; Data bank 84, total bank size: 8146 bytes
+; Data bank 84, total bank size: 8169 bytes
 	sprite_data_endgame:	; Size: 4396
 		.incbin "EXPORTS/sprite/endgame.bin"
-	.export level_data_illusion
-	level_data_illusion:
-	; Header
-		.byte <sprite_data_illusion ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_illusion) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_illusion >> 13) ;_________ Sprite data bank
-		.byte song_operation_evolution ;______________ Song ID
-		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_____________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
-		.byte $0F ;___________________________________ Starting background color
-		.byte $0F ;___________________________________ Starting ground color
-		.byte 57 ;____________________________________ Level height
+	.export level_data_sonicwave_26
+	level_data_sonicwave_26:
 	; Level data
-		.incbin "EXPORTS/level/illusion.lz.bin" ; Size: 3737
+		.incbin "EXPORTS/level/sonicwave.lz.1.bin" ; Size: 3773
 
 	.align 8192
 
 
-; Data bank 85, total bank size: 8190 bytes
+; Data bank 85, total bank size: 8144 bytes
 	.export level_data_reincarnation
 	level_data_reincarnation:
 	; Header
@@ -3198,7 +3189,7 @@
 		.byte song_the_beginning_of_time ;_________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -3208,11 +3199,8 @@
 	; Level data
 		.incbin "EXPORTS/level/reincarnation.lz.bin" ; Size: 4330
 
-	.export level_data_futurefunkfix_23
-	level_data_futurefunkfix_23:
-	; Level data
-		.incbin "EXPORTS/level/futurefunkfix.lz.2.bin" ; Size: 3847
-
+	sprite_data_fireaura:	; Size: 3801
+		.incbin "EXPORTS/sprite/fireaura.bin"
 	.align 8192
 
 
@@ -3226,7 +3214,7 @@
 		.byte song_xenogenesis ;__________________________ Song ID
 		.byte (1 << 4) | 0 ;______________________________ Starting game mode and speed
 		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
@@ -3244,7 +3232,7 @@
 	.align 8192
 
 
-; Data bank 87, total bank size: 8134 bytes
+; Data bank 87, total bank size: 8180 bytes
 	.export level_data_infinitecircles
 	level_data_infinitecircles:
 	; Header
@@ -3254,7 +3242,7 @@
 		.byte song_infinite_power ;__________________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
@@ -3264,8 +3252,11 @@
 	; Level data
 		.incbin "EXPORTS/level/infinitecircles.lz.bin" ; Size: 4320
 
-	sprite_data_fireaura:	; Size: 3801
-		.incbin "EXPORTS/sprite/fireaura.bin"
+	.export level_data_futurefunkfix_23
+	level_data_futurefunkfix_23:
+	; Level data
+		.incbin "EXPORTS/level/futurefunkfix.lz.2.bin" ; Size: 3847
+
 	.align 8192
 
 
@@ -3279,7 +3270,7 @@
 		.byte song_polargeist ;________________________ Song ID
 		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSC ;_____________ Spike Set, Block Set
@@ -3294,7 +3285,7 @@
 	.align 8192
 
 
-; Data bank 89, total bank size: 8192 bytes
+; Data bank 89, total bank size: 8170 bytes
 	.export level_data_greif
 	level_data_greif:
 	; Header
@@ -3304,7 +3295,7 @@
 		.byte song_stalemate_greif_cut ;___________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -3313,181 +3304,6 @@
 		.byte 27 ;_________________________________ Level height
 	; Level data
 		.incbin "EXPORTS/level/greif.lz.bin" ; Size: 4233
-
-	sprite_data_funnygameholiday:	; Size: 3946
-		.incbin "EXPORTS/sprite/funnygameholiday.bin"
-	.align 8192
-
-
-; Data bank 8A, total bank size: 8189 bytes
-	.export level_data_moonlight
-	level_data_moonlight:
-	; Header
-		.byte <sprite_data_moonlight ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_moonlight) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_moonlight >> 13) ;_________ Sprite data bank
-		.byte song_fantasy ;___________________________ Song ID
-		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/moonlight.lz.bin" ; Size: 4220
-
-	sprite_data_reincarnation:	; Size: 3956
-		.incbin "EXPORTS/sprite/reincarnation.bin"
-	.align 8192
-
-
-; Data bank 8B, total bank size: 8189 bytes
-	.export level_data_powertrip
-	level_data_powertrip:
-	; Header
-		.byte <sprite_data_powertrip ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_powertrip) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_powertrip >> 13) ;_________ Sprite data bank
-		.byte song_power_trip ;________________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/powertrip.lz.bin" ; Size: 4195
-
-	sprite_data_ninecircleseasy:	; Size: 3981
-		.incbin "EXPORTS/sprite/ninecircleseasy.bin"
-	.align 8192
-
-
-; Data bank 8C, total bank size: 8139 bytes
-	.export level_data_wcropolix
-	level_data_wcropolix:
-	; Header
-		.byte <sprite_data_wcropolix ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_wcropolix) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_wcropolix >> 13) ;_________ Sprite data bank
-		.byte song_fracture_wcropolix ;________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/wcropolix.lz.bin" ; Size: 4154
-
-	.export level_data_shadowtemple
-	level_data_shadowtemple:
-	; Header
-		.byte <sprite_data_shadowtemple ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_shadowtemple) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_shadowtemple >> 13) ;_________ Sprite data bank
-		.byte song_clubstep ;_____________________________ Song ID
-		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
-		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_____________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
-		.byte $00 ;_______________________________________ Starting background color
-		.byte $0F ;_______________________________________ Starting ground color
-		.byte 27 ;________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/shadowtemple.lz.bin" ; Size: 3959
-
-	.align 8192
-
-
-; Data bank 8D, total bank size: 8190 bytes
-	.export level_data_denouement
-	level_data_denouement:
-	; Header
-		.byte <sprite_data_denouement ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_denouement) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_denouement >> 13) ;_________ Sprite data bank
-		.byte song_glory ;______________________________ Song ID
-		.byte (4 << 4) | 6 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
-		.byte $03 ;_____________________________________ Starting background color
-		.byte $0F ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/denouement.lz.bin" ; Size: 4146
-
-	sprite_data_luckydraw:	; Size: 4031
-		.incbin "EXPORTS/sprite/luckydraw.bin"
-	.align 8192
-
-
-; Data bank 8E, total bank size: 8095 bytes
-	.export level_data_theoryofeverything
-	level_data_theoryofeverything:
-	; Header
-		.byte <sprite_data_theoryofeverything ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_theoryofeverything) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_theoryofeverything >> 13) ;_________ Sprite data bank
-		.byte song_theory_of_everything ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_____________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECOCLOUD ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESC << 4) | _BLOCKSB ;______________________ Spike Set, Block Set
-		.byte $05 ;_____________________________________________ Starting background color
-		.byte $15 ;_____________________________________________ Starting ground color
-		.byte 57 ;______________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/theoryofeverything.lz.bin" ; Size: 4136
-
-	sprite_data_infinitecircles:	; Size: 3946
-		.incbin "EXPORTS/sprite/infinitecircles.bin"
-	.align 8192
-
-
-; Data bank 8F, total bank size: 8077 bytes
-	sprite_data_ninecircles:	; Size: 4146
-		.incbin "EXPORTS/sprite/ninecircles.bin"
-	sprite_data_demonpyrophoric:	; Size: 3931
-		.incbin "EXPORTS/sprite/demonpyrophoric.bin"
-	.align 8192
-
-
-; Data bank 90, total bank size: 8062 bytes
-	.export level_data_selectpaymenttype
-	level_data_selectpaymenttype:
-	; Header
-		.byte <sprite_data_selectpaymenttype ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_selectpaymenttype) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_selectpaymenttype >> 13) ;_________ Sprite data bank
-		.byte song_select_payment_type ;_______________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _EXTRASPRITES1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________________ Spike Set, Block Set
-		.byte $12 ;____________________________________________ Starting background color
-		.byte $02 ;____________________________________________ Starting ground color
-		.byte 27 ;_____________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/selectpaymenttype.lz.bin" ; Size: 4125
 
 	.export level_data_outerspace
 	level_data_outerspace:
@@ -3498,7 +3314,7 @@
 		.byte song_menu_theme ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -3511,7 +3327,182 @@
 	.align 8192
 
 
-; Data bank 91, total bank size: 8016 bytes
+; Data bank 8A, total bank size: 8164 bytes
+	.export level_data_moonlight
+	level_data_moonlight:
+	; Header
+		.byte <sprite_data_moonlight ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_moonlight) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_moonlight >> 13) ;_________ Sprite data bank
+		.byte song_fantasy ;___________________________ Song ID
+		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _EXTRASPRITES1 ;______________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/moonlight.lz.bin" ; Size: 4220
+
+	sprite_data_demonpyrophoric:	; Size: 3931
+		.incbin "EXPORTS/sprite/demonpyrophoric.bin"
+	.align 8192
+
+
+; Data bank 8B, total bank size: 8154 bytes
+	.export level_data_powertrip
+	level_data_powertrip:
+	; Header
+		.byte <sprite_data_powertrip ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_powertrip) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_powertrip >> 13) ;_________ Sprite data bank
+		.byte song_power_trip ;________________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/powertrip.lz.bin" ; Size: 4195
+
+	sprite_data_infinitecircles:	; Size: 3946
+		.incbin "EXPORTS/sprite/infinitecircles.bin"
+	.align 8192
+
+
+; Data bank 8C, total bank size: 8113 bytes
+	.export level_data_wcropolix
+	level_data_wcropolix:
+	; Header
+		.byte <sprite_data_wcropolix ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_wcropolix) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_wcropolix >> 13) ;_________ Sprite data bank
+		.byte song_fracture_wcropolix ;________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $0F ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/wcropolix.lz.bin" ; Size: 4154
+
+	sprite_data_funnygameholiday:	; Size: 3946
+		.incbin "EXPORTS/sprite/funnygameholiday.bin"
+	.align 8192
+
+
+; Data bank 8D, total bank size: 8115 bytes
+	.export level_data_denouement
+	level_data_denouement:
+	; Header
+		.byte <sprite_data_denouement ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_denouement) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_denouement >> 13) ;_________ Sprite data bank
+		.byte song_glory ;______________________________ Song ID
+		.byte (4 << 4) | 6 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
+		.byte $03 ;_____________________________________ Starting background color
+		.byte $0F ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/denouement.lz.bin" ; Size: 4146
+
+	sprite_data_reincarnation:	; Size: 3956
+		.incbin "EXPORTS/sprite/reincarnation.bin"
+	.align 8192
+
+
+; Data bank 8E, total bank size: 8121 bytes
+	.export level_data_theoryofeverything
+	level_data_theoryofeverything:
+	; Header
+		.byte <sprite_data_theoryofeverything ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_theoryofeverything) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_theoryofeverything >> 13) ;_________ Sprite data bank
+		.byte song_theory_of_everything ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_____________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECOCLOUD ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESC << 4) | _BLOCKSB ;______________________ Spike Set, Block Set
+		.byte $05 ;_____________________________________________ Starting background color
+		.byte $15 ;_____________________________________________ Starting ground color
+		.byte 57 ;______________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/theoryofeverything.lz.bin" ; Size: 4136
+
+	.export level_data_shadowtemple
+	level_data_shadowtemple:
+	; Header
+		.byte <sprite_data_shadowtemple ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_shadowtemple) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_shadowtemple >> 13) ;_________ Sprite data bank
+		.byte song_clubstep ;_____________________________ Song ID
+		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;_______________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;________________ Spike Set, Block Set
+		.byte $00 ;_______________________________________ Starting background color
+		.byte $0F ;_______________________________________ Starting ground color
+		.byte 27 ;________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/shadowtemple.lz.bin" ; Size: 3959
+
+	.align 8192
+
+
+; Data bank 8F, total bank size: 8127 bytes
+	sprite_data_ninecircles:	; Size: 4146
+		.incbin "EXPORTS/sprite/ninecircles.bin"
+	sprite_data_ninecircleseasy:	; Size: 3981
+		.incbin "EXPORTS/sprite/ninecircleseasy.bin"
+	.align 8192
+
+
+; Data bank 90, total bank size: 8169 bytes
+	.export level_data_selectpaymenttype
+	level_data_selectpaymenttype:
+	; Header
+		.byte <sprite_data_selectpaymenttype ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_selectpaymenttype) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_selectpaymenttype >> 13) ;_________ Sprite data bank
+		.byte song_select_payment_type ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _EXTRASPRITES1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSD ;_____________________ Spike Set, Block Set
+		.byte $12 ;____________________________________________ Starting background color
+		.byte $02 ;____________________________________________ Starting ground color
+		.byte 27 ;_____________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/selectpaymenttype.lz.bin" ; Size: 4125
+
+	sprite_data_luckydraw:	; Size: 4031
+		.incbin "EXPORTS/sprite/luckydraw.bin"
+	.align 8192
+
+
+; Data bank 91, total bank size: 8093 bytes
 	.export level_data_pyrophoric
 	level_data_pyrophoric:
 	; Header
@@ -3521,7 +3512,7 @@
 		.byte song_pyrophoric_legacy_remix ;____________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -3540,7 +3531,7 @@
 		.byte song_off_to_mars ;_______________________ Song ID
 		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
 		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
@@ -3550,39 +3541,25 @@
 	; Level data
 		.incbin "EXPORTS/level/offtomars.lz.bin" ; Size: 3860
 
-	.export level_data_doubletripletrial
-	level_data_doubletripletrial:
-	; Header
-		.byte <sprite_data_doubletripletrial ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_doubletripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_doubletripletrial >> 13) ;_________ Sprite data bank
-		.byte song_dastardly ;_________________________________ Song ID
-		.byte (4 << 4) | 0 ;___________________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;____________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________________ Spike Set, Block Set
-		.byte $00 ;____________________________________________ Starting background color
-		.byte $00 ;____________________________________________ Starting ground color
-		.byte 27 ;_____________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/doubletripletrial.lz.bin" ; Size: 251
-
+	sprite_data_thesewers:	; Size: 341
+		.incbin "EXPORTS/sprite/thesewers.bin"
 	.align 8192
 
 
-; Data bank 92, total bank size: 8148 bytes
+; Data bank 92, total bank size: 8092 bytes
 	sprite_data_cosmicdolphin:	; Size: 3646
 		.incbin "EXPORTS/sprite/cosmicdolphin.bin"
 	sprite_data_illusion:	; Size: 3641
 		.incbin "EXPORTS/sprite/illusion.bin"
-	sprite_data_retray:	; Size: 861
-		.incbin "EXPORTS/sprite/retray.bin"
+	.export level_data_eon_24
+	level_data_eon_24:
+	; Level data
+		.incbin "EXPORTS/level/eon.lz.1.bin" ; Size: 805
+
 	.align 8192
 
 
-; Data bank 93, total bank size: 8144 bytes
+; Data bank 93, total bank size: 8112 bytes
 	.export level_data_wintherace
 	level_data_wintherace:
 	; Header
@@ -3592,7 +3569,7 @@
 		.byte song_win_the_race ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
@@ -3602,27 +3579,27 @@
 	; Level data
 		.incbin "EXPORTS/level/wintherace.lz.bin" ; Size: 3496
 
-	.export level_data_groundtoretray
-	level_data_groundtoretray:
+	sprite_data_dorabaebasic8:	; Size: 3456
+		.incbin "EXPORTS/sprite/dorabaebasic8.bin"
+	.export level_data_thecellar
+	level_data_thecellar:
 	; Header
-		.byte <sprite_data_groundtoretray ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_groundtoretray) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_groundtoretray >> 13) ;_________ Sprite data bank
-		.byte song_ground_to_retray ;_______________________ Song ID
-		.byte (1 << 4) | 0 ;________________________________ Starting game mode and speed
-		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;_________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
-		.byte $03 ;_________________________________________ Starting background color
-		.byte $00 ;_________________________________________ Starting ground color
-		.byte 27 ;__________________________________________ Level height
+		.byte <sprite_data_thecellar ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_thecellar) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_thecellar >> 13) ;_________ Sprite data bank
+		.byte song_scheming_weasel ;___________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (1 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $1C ;____________________________________ Starting background color
+		.byte $0F ;____________________________________ Starting ground color
+		.byte 57 ;_____________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/groundtoretray.lz.bin" ; Size: 3196
+		.incbin "EXPORTS/level/thecellar.lz.bin" ; Size: 1134
 
-	sprite_data_subtleoddities:	; Size: 1426
-		.incbin "EXPORTS/sprite/subtleoddities.bin"
 	.align 8192
 
 
@@ -3636,7 +3613,7 @@
 		.byte song_base_after_base ;____________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESB << 4) | _BLOCKSB ;______________ Spike Set, Block Set
@@ -3655,7 +3632,7 @@
 		.byte song_time_machine ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
@@ -3670,7 +3647,7 @@
 	.align 8192
 
 
-; Data bank 95, total bank size: 7966 bytes
+; Data bank 95, total bank size: 8140 bytes
 	sprite_data_invisiblelight:	; Size: 3071
 		.incbin "EXPORTS/sprite/invisiblelight.bin"
 	.export level_data_dorabaebasic6
@@ -3682,7 +3659,7 @@
 		.byte song_theory_of_everything ;__________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
@@ -3692,29 +3669,29 @@
 	; Level data
 		.incbin "EXPORTS/level/dorabaebasic6.lz.bin" ; Size: 3027
 
-	.export level_data_stereomadness
-	level_data_stereomadness:
+	.export level_data_baseafterbase
+	level_data_baseafterbase:
 	; Header
-		.byte <sprite_data_stereomadness ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_stereomadness) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_stereomadness >> 13) ;_________ Sprite data bank
-		.byte song_stereo_madness ;________________________ Song ID
+		.byte <sprite_data_baseafterbase ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_baseafterbase) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_baseafterbase >> 13) ;_________ Sprite data bank
+		.byte song_base_after_base ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
 		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_________________ Spike Set, Block Set
-		.byte $12 ;________________________________________ Starting background color
-		.byte $02 ;________________________________________ Starting ground color
+		.byte $11 ;________________________________________ Starting background color
+		.byte $11 ;________________________________________ Starting ground color
 		.byte 27 ;_________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/stereomadness.lz.bin" ; Size: 1842
+		.incbin "EXPORTS/level/baseafterbase.lz.bin" ; Size: 2016
 
 	.align 8192
 
 
-; Data bank 96, total bank size: 8161 bytes
+; Data bank 96, total bank size: 8141 bytes
 	sprite_data_trythisgd:	; Size: 3031
 		.incbin "EXPORTS/sprite/trythisgd.bin"
 	.export level_data_cycles
@@ -3726,7 +3703,7 @@
 		.byte song_cycles ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
@@ -3736,8 +3713,8 @@
 	; Level data
 		.incbin "EXPORTS/level/cycles.lz.bin" ; Size: 2996
 
-	sprite_data_problematic:	; Size: 2121
-		.incbin "EXPORTS/sprite/problematic.bin"
+	sprite_data_somewhereinaforest:	; Size: 2101
+		.incbin "EXPORTS/sprite/somewhereinaforest.bin"
 	.align 8192
 
 
@@ -3751,7 +3728,7 @@
 	.align 8192
 
 
-; Data bank 98, total bank size: 8192 bytes
+; Data bank 98, total bank size: 8182 bytes
 	.export level_data_watertemple
 	level_data_watertemple:
 	; Header
@@ -3761,7 +3738,7 @@
 		.byte song_cant_let_go ;_________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -3776,25 +3753,22 @@
 	; Level data
 		.incbin "EXPORTS/level/thesteamworks.lz.1.bin" ; Size: 2797
 
-	.export level_data_skeletalshenanigans_18
-	level_data_skeletalshenanigans_18:
-	; Level data
-		.incbin "EXPORTS/level/skeletalshenanigans.lz.1.bin" ; Size: 2586
-
+	sprite_data_clutterfunk:	; Size: 2576
+		.incbin "EXPORTS/sprite/clutterfunk.bin"
 	.align 8192
 
 
-; Data bank 99, total bank size: 8188 bytes
+; Data bank 99, total bank size: 8178 bytes
 	sprite_data_dreamer:	; Size: 2791
 		.incbin "EXPORTS/sprite/dreamer.bin"
-	sprite_data_fairydust:	; Size: 2786
-		.incbin "EXPORTS/sprite/fairydust.bin"
-	sprite_data_dorabaebasic4:	; Size: 2611
-		.incbin "EXPORTS/sprite/dorabaebasic4.bin"
+	sprite_data_clubstep:	; Size: 2786
+		.incbin "EXPORTS/sprite/clubstep.bin"
+	sprite_data_electromanadventures:	; Size: 2601
+		.incbin "EXPORTS/sprite/electromanadventures.bin"
 	.align 8192
 
 
-; Data bank 9A, total bank size: 8180 bytes
+; Data bank 9A, total bank size: 8157 bytes
 	.export level_data_thelightningroad
 	level_data_thelightningroad:
 	; Header
@@ -3804,7 +3778,7 @@
 		.byte song_dry_out ;__________________________________ Song ID
 		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
 		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSA ;____________________ Spike Set, Block Set
@@ -3814,28 +3788,48 @@
 	; Level data
 		.incbin "EXPORTS/level/thelightningroad.lz.bin" ; Size: 2765
 
-	sprite_data_hi:	; Size: 2706
-		.incbin "EXPORTS/sprite/hi.bin"
+	sprite_data_skeletalshenanigans:	; Size: 2751
+		.incbin "EXPORTS/sprite/skeletalshenanigans.bin"
+	.export level_data_everymadness
+	level_data_everymadness:
+	; Header
+		.byte <sprite_data_everymadness ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_everymadness) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_everymadness >> 13) ;_________ Sprite data bank
+		.byte song_every_madness ;________________________ Song ID
+		.byte (0 << 4) | 0 ;______________________________ Starting game mode and speed
+		.byte ($B0) ;_____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_______________________ Force platformer, Disable parallax
+		.byte (0 << 7) | _DECO1 ;_________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;________________ Spike Set, Block Set
+		.byte $12 ;_______________________________________ Starting background color
+		.byte $02 ;_______________________________________ Starting ground color
+		.byte 27 ;________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/everymadness.lz.bin" ; Size: 2615
+
+	.align 8192
+
+
+; Data bank 9B, total bank size: 8008 bytes
 	sprite_data_deadlyclubstep:	; Size: 2696
 		.incbin "EXPORTS/sprite/deadlyclubstep.bin"
+	sprite_data_bloodbath:	; Size: 2661
+		.incbin "EXPORTS/sprite/bloodbath.bin"
+	sprite_data_powertrip:	; Size: 2651
+		.incbin "EXPORTS/sprite/powertrip.bin"
 	.align 8192
 
 
-; Data bank 9B, total bank size: 8169 bytes
-	sprite_data_motion:	; Size: 2641
-		.incbin "EXPORTS/sprite/motion.bin"
-	sprite_data_xstep:	; Size: 2616
-		.incbin "EXPORTS/sprite/xstep.bin"
-	sprite_data_electromanadventures:	; Size: 2601
-		.incbin "EXPORTS/sprite/electromanadventures.bin"
-	sprite_data_acropolis:	; Size: 311
-		.incbin "EXPORTS/sprite/acropolis.bin"
-	.align 8192
-
-
-; Data bank 9C, total bank size: 8034 bytes
+; Data bank 9C, total bank size: 8076 bytes
 	sprite_data_generationretro:	; Size: 2601
 		.incbin "EXPORTS/sprite/generationretro.bin"
+	.export level_data_skeletalshenanigans_18
+	level_data_skeletalshenanigans_18:
+	; Level data
+		.incbin "EXPORTS/level/skeletalshenanigans.lz.1.bin" ; Size: 2586
+
 	.export level_data_subzero
 	level_data_subzero:
 	; Header
@@ -3845,7 +3839,7 @@
 		.byte song_cant_let_go ;_____________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
@@ -3855,43 +3849,44 @@
 	; Level data
 		.incbin "EXPORTS/level/subzero.lz.bin" ; Size: 2563
 
-	sprite_data_clutterfunk:	; Size: 2576
-		.incbin "EXPORTS/sprite/clutterfunk.bin"
-	sprite_data_thesecrethollow:	; Size: 281
-		.incbin "EXPORTS/sprite/thesecrethollow.bin"
+	.export level_data_thetripletrial
+	level_data_thetripletrial:
+	; Header
+		.byte <sprite_data_thetripletrial ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_thetripletrial) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_thetripletrial >> 13) ;_________ Sprite data bank
+		.byte song_dastardly ;______________________________ Song ID
+		.byte (0 << 4) | 0 ;________________________________ Starting game mode and speed
+		.byte ($B0) ;_______________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;_______________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;___________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;__________________ Spike Set, Block Set
+		.byte $00 ;_________________________________________ Starting background color
+		.byte $00 ;_________________________________________ Starting ground color
+		.byte 27 ;__________________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/thetripletrial.lz.bin" ; Size: 300
+
 	.align 8192
 
 
-; Data bank 9D, total bank size: 8117 bytes
+; Data bank 9D, total bank size: 8099 bytes
 	sprite_data_jawbreaker:	; Size: 2571
 		.incbin "EXPORTS/sprite/jawbreaker.bin"
 	sprite_data_darkparadise:	; Size: 2561
 		.incbin "EXPORTS/sprite/darkparadise.bin"
-	.export level_data_nicktoons
-	level_data_nicktoons:
-	; Header
-		.byte <sprite_data_nicktoons ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_nicktoons) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_nicktoons >> 13) ;_________ Sprite data bank
-		.byte song_unity ;_____________________________ Song ID
-		.byte (1 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($00) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $28 ;____________________________________ Starting background color
-		.byte $27 ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
+	.export level_data_highlife_13
+	level_data_highlife_13:
 	; Level data
-		.incbin "EXPORTS/level/nicktoons.lz.bin" ; Size: 2506
+		.incbin "EXPORTS/level/highlife.lz.1.bin" ; Size: 2551
 
-	sprite_data_thechallenge:	; Size: 466
-		.incbin "EXPORTS/sprite/thechallenge.bin"
+	sprite_data_foresttemple:	; Size: 416
+		.incbin "EXPORTS/sprite/foresttemple.bin"
 	.align 8192
 
 
-; Data bank 9E, total bank size: 8189 bytes
+; Data bank 9E, total bank size: 8161 bytes
 	.export level_data_hungrymanadventures
 	level_data_hungrymanadventures:
 	; Header
@@ -3901,7 +3896,7 @@
 		.byte song_hungryman_adventures ;________________________ Song ID
 		.byte (0 << 4) | 0 ;_____________________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;______________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECOCLOUD ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________________ Spike Set, Block Set
@@ -3911,19 +3906,16 @@
 	; Level data
 		.incbin "EXPORTS/level/hungrymanadventures.lz.bin" ; Size: 2500
 
+	sprite_data_dash:	; Size: 2486
+		.incbin "EXPORTS/sprite/dash.bin"
 	sprite_data_groundtospace:	; Size: 2486
 		.incbin "EXPORTS/sprite/groundtospace.bin"
-	sprite_data_toeiiv2:	; Size: 2321
-		.incbin "EXPORTS/sprite/toeiiv2.bin"
-	.export level_data_demonpyrophoric_20
-	level_data_demonpyrophoric_20:
-	; Level data
-		.incbin "EXPORTS/level/demonpyrophoric.lz.1.bin" ; Size: 869
-
+	sprite_data_doubletripletrial:	; Size: 676
+		.incbin "EXPORTS/sprite/doubletripletrial.bin"
 	.align 8192
 
 
-; Data bank 9F, total bank size: 8184 bytes
+; Data bank 9F, total bank size: 8103 bytes
 	.export level_data_subtleoddities_9
 	level_data_subtleoddities_9:
 	; Level data
@@ -3940,7 +3932,7 @@
 		.byte song_unity ;_________________________ Song ID
 		.byte (1 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_________ Spike Set, Block Set
@@ -3950,25 +3942,8 @@
 	; Level data
 		.incbin "EXPORTS/level/unity.lz.bin" ; Size: 2266
 
-	.export level_data_thetower
-	level_data_thetower:
-	; Header
-		.byte <sprite_data_thetower ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_thetower) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_thetower >> 13) ;_________ Sprite data bank
-		.byte song_desert_city ;______________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
-		.byte ($A0) ;_________________________________ Spawn Y Position (high byte)
-		.byte ($80) ;_________________________________ Y Scroll Position (low byte)
-		.byte (1 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _EXTRASPRITES1 ;_____________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
-		.byte $03 ;___________________________________ Starting background color
-		.byte $0F ;___________________________________ Starting ground color
-		.byte 32 ;____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/thetower.lz.bin" ; Size: 1324
-
+	sprite_data_everymadness:	; Size: 1256
+		.incbin "EXPORTS/sprite/everymadness.bin"
 	.align 8192
 
 
@@ -3988,7 +3963,7 @@
 		.byte song_stereo_madness ;________________ Song ID
 		.byte (0 << 4) | 0 ;_______________________ Starting game mode and speed
 		.byte ($B0) ;______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;__________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;_________ Spike Set, Block Set
@@ -4013,7 +3988,7 @@
 		.byte song_slow_down ;___________________________ Song ID
 		.byte (1 << 4) | 4 ;_____________________________ Starting game mode and speed
 		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;____________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;______________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSB ;_______________ Spike Set, Block Set
@@ -4034,7 +4009,7 @@
 		.byte song_ultimatedestruction ;________________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;_______________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;______________________ Spike Set, Block Set
@@ -4047,86 +4022,30 @@
 	.align 8192
 
 
-; Data bank A2, total bank size: 8189 bytes
+; Data bank A2, total bank size: 8124 bytes
 	sprite_data_azuronxolax:	; Size: 2186
 		.incbin "EXPORTS/sprite/azuronxolax.bin"
-	sprite_data_cycles:	; Size: 2086
-		.incbin "EXPORTS/sprite/cycles.bin"
-	sprite_data_fofii_fofii_fofii:	; Size: 2086
-		.incbin "EXPORTS/sprite/fofii_fofii_fofii.bin"
-	.export level_data_bestautomaticlvl
-	level_data_bestautomaticlvl:
+	.export level_data_thesecrethollow
+	level_data_thesecrethollow:
 	; Header
-		.byte <sprite_data_bestautomaticlvl ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_bestautomaticlvl) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_bestautomaticlvl >> 13) ;_________ Sprite data bank
-		.byte song_dry_out ;__________________________________ Song ID
-		.byte (0 << 4) | 0 ;__________________________________ Starting game mode and speed
-		.byte ($B0) ;_________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_________________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;___________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_____________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;____________________ Spike Set, Block Set
-		.byte $16 ;___________________________________________ Starting background color
-		.byte $10 ;___________________________________________ Starting ground color
-		.byte 36 ;____________________________________________ Level height
+		.byte <sprite_data_thesecrethollow ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_thesecrethollow) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_thesecrethollow >> 13) ;_________ Sprite data bank
+		.byte song_scheming_weasel ;_________________________ Song ID
+		.byte (0 << 4) | 4 ;_________________________________ Starting game mode and speed
+		.byte ($40) ;________________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
+		.byte (1 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;___________________ Spike Set, Block Set
+		.byte $03 ;__________________________________________ Starting background color
+		.byte $0F ;__________________________________________ Starting ground color
+		.byte 51 ;___________________________________________ Level height
 	; Level data
-		.incbin "EXPORTS/level/bestautomaticlvl.lz.bin" ; Size: 1818
+		.incbin "EXPORTS/level/thesecrethollow.lz.bin" ; Size: 2121
 
-	.align 8192
-
-
-; Data bank A3, total bank size: 8175 bytes
-	sprite_data_element111rg:	; Size: 2086
-		.incbin "EXPORTS/sprite/element111rg.bin"
-	sprite_data_silentclubstep:	; Size: 1851
-		.incbin "EXPORTS/sprite/silentclubstep.bin"
-	sprite_data_deadlocked:	; Size: 1846
-		.incbin "EXPORTS/sprite/deadlocked.bin"
-	sprite_data_outerspace:	; Size: 1821
-		.incbin "EXPORTS/sprite/outerspace.bin"
-	sprite_data_nicktoons:	; Size: 571
-		.incbin "EXPORTS/sprite/nicktoons.bin"
-	.align 8192
-
-
-; Data bank A4, total bank size: 8180 bytes
-	sprite_data_storymadness:	; Size: 1781
-		.incbin "EXPORTS/sprite/storymadness.bin"
-	sprite_data_styx:	; Size: 1781
-		.incbin "EXPORTS/sprite/styx.bin"
-	sprite_data_cataclysm:	; Size: 1781
-		.incbin "EXPORTS/sprite/cataclysm.bin"
-	.export level_data_polargeist
-	level_data_polargeist:
-	; Header
-		.byte <sprite_data_polargeist ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_polargeist) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_polargeist >> 13) ;_________ Sprite data bank
-		.byte song_polargeist ;_________________________ Song ID
-		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
-		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
-		.byte $2A ;_____________________________________ Starting background color
-		.byte $1A ;_____________________________________ Starting ground color
-		.byte 27 ;______________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/polargeist.lz.bin" ; Size: 1743
-
-	sprite_data_leveleasy:	; Size: 1081
-		.incbin "EXPORTS/sprite/leveleasy.bin"
-	.align 8192
-
-
-; Data bank A5, total bank size: 8177 bytes
-	.export level_data_cryogenic_2
-	level_data_cryogenic_2:
-	; Level data
-		.incbin "EXPORTS/level/cryogenic.lz.1.bin" ; Size: 1676
-
+	sprite_data_blastprocessing:	; Size: 2131
+		.incbin "EXPORTS/sprite/blastprocessing.bin"
 	.export level_data_lookatthislevel
 	level_data_lookatthislevel:
 	; Header
@@ -4136,7 +4055,7 @@
 		.byte song_driving_by_night ;________________________ Song ID
 		.byte (1 << 4) | 0 ;_________________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (1 << 1) ;__________________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;____________________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________________ Spike Set, Block Set
@@ -4146,16 +4065,110 @@
 	; Level data
 		.incbin "EXPORTS/level/lookatthislevel.lz.bin" ; Size: 1660
 
-	sprite_data_lostinthewoods:	; Size: 1671
-		.incbin "EXPORTS/sprite/lostinthewoods.bin"
-	sprite_data_wintherace:	; Size: 1661
-		.incbin "EXPORTS/sprite/wintherace.bin"
-	sprite_data_subzero:	; Size: 1496
-		.incbin "EXPORTS/sprite/subzero.bin"
 	.align 8192
 
 
-; Data bank A6, total bank size: 8173 bytes
+; Data bank A3, total bank size: 8032 bytes
+	sprite_data_element111rg:	; Size: 2086
+		.incbin "EXPORTS/sprite/element111rg.bin"
+	.export level_data_cantletgo
+	level_data_cantletgo:
+	; Header
+		.byte <sprite_data_cantletgo ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_cantletgo) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_cantletgo >> 13) ;_________ Sprite data bank
+		.byte song_cant_let_go ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_____________ Spike Set, Block Set
+		.byte $14 ;____________________________________ Starting background color
+		.byte $04 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/cantletgo.lz.bin" ; Size: 2040
+
+	.export level_data_explorers
+	level_data_explorers:
+	; Header
+		.byte <sprite_data_explorers ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_explorers) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_explorers >> 13) ;_________ Sprite data bank
+		.byte song_explorers ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
+		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;__________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
+		.byte $03 ;____________________________________ Starting background color
+		.byte $03 ;____________________________________ Starting ground color
+		.byte 27 ;_____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/explorers.lz.bin" ; Size: 2029
+
+	sprite_data_silentclubstep:	; Size: 1851
+		.incbin "EXPORTS/sprite/silentclubstep.bin"
+	.align 8192
+
+
+; Data bank A4, total bank size: 8044 bytes
+	sprite_data_outerspace:	; Size: 1821
+		.incbin "EXPORTS/sprite/outerspace.bin"
+	.export level_data_tetrix_12
+	level_data_tetrix_12:
+	; Level data
+		.incbin "EXPORTS/level/tetrix.lz.1.bin" ; Size: 1792
+
+	sprite_data_storymadness:	; Size: 1781
+		.incbin "EXPORTS/sprite/storymadness.bin"
+	sprite_data_styx:	; Size: 1781
+		.incbin "EXPORTS/sprite/styx.bin"
+	.export level_data_demonpyrophoric_20
+	level_data_demonpyrophoric_20:
+	; Level data
+		.incbin "EXPORTS/level/demonpyrophoric.lz.1.bin" ; Size: 869
+
+	.align 8192
+
+
+; Data bank A5, total bank size: 8135 bytes
+	.export level_data_polargeist
+	level_data_polargeist:
+	; Header
+		.byte <sprite_data_polargeist ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_polargeist) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_polargeist >> 13) ;_________ Sprite data bank
+		.byte song_polargeist ;_________________________ Song ID
+		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
+		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;______________ Spike Set, Block Set
+		.byte $2A ;_____________________________________ Starting background color
+		.byte $1A ;_____________________________________ Starting ground color
+		.byte 27 ;______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/polargeist.lz.bin" ; Size: 1743
+
+	sprite_data_thelightningroad:	; Size: 1721
+		.incbin "EXPORTS/sprite/thelightningroad.bin"
+	sprite_data_greif:	; Size: 1716
+		.incbin "EXPORTS/sprite/greif.bin"
+	sprite_data_everyend:	; Size: 1701
+		.incbin "EXPORTS/sprite/everyend.bin"
+	.export level_data_birdbrain_11
+	level_data_birdbrain_11:
+	; Level data
+		.incbin "EXPORTS/level/birdbrain.lz.1.bin" ; Size: 1241
+
+	.align 8192
+
+
+; Data bank A6, total bank size: 8008 bytes
 	.export level_data_dryout
 	level_data_dryout:
 	; Header
@@ -4165,7 +4178,7 @@
 		.byte song_dry_out ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
@@ -4184,7 +4197,7 @@
 		.byte song_aether_new ;______________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
@@ -4194,32 +4207,80 @@
 	; Level data
 		.incbin "EXPORTS/level/feather.lz.bin" ; Size: 1504
 
+	sprite_data_aftermath:	; Size: 1501
+		.incbin "EXPORTS/sprite/aftermath.bin"
+	sprite_data_subzero:	; Size: 1496
+		.incbin "EXPORTS/sprite/subzero.bin"
 	.export level_data_demoncryogenic_21
 	level_data_demoncryogenic_21:
 	; Level data
 		.incbin "EXPORTS/level/demoncryogenic.lz.1.bin" ; Size: 1495
 
-	sprite_data_fingerdash:	; Size: 1491
-		.incbin "EXPORTS/sprite/fingerdash.bin"
-	sprite_data_explorers:	; Size: 1411
-		.incbin "EXPORTS/sprite/explorers.bin"
-	sprite_data_trolledfix:	; Size: 726
-		.incbin "EXPORTS/sprite/trolledfix.bin"
+	sprite_data_thechallenge:	; Size: 466
+		.incbin "EXPORTS/sprite/thechallenge.bin"
 	.align 8192
 
 
-; Data bank A7, total bank size: 8164 bytes
+; Data bank A7, total bank size: 8187 bytes
+	sprite_data_subtleoddities:	; Size: 1426
+		.incbin "EXPORTS/sprite/subtleoddities.bin"
+	.export level_data_backontrack
+	level_data_backontrack:
+	; Header
+		.byte <sprite_data_backontrack ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_backontrack) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_backontrack >> 13) ;_________ Sprite data bank
+		.byte song_back_on_track ;_______________________ Song ID
+		.byte (0 << 4) | 0 ;_____________________________ Starting game mode and speed
+		.byte ($B0) ;____________________________________ Spawn Y Position (high byte)
+		.byte ($CF) ;____________________________________ Y Scroll Position (low byte)
+		.byte (0 << 0) | (0 << 1) ;______________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _DECO1 ;________________________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSA ;_______________ Spike Set, Block Set
+		.byte $14 ;______________________________________ Starting background color
+		.byte $14 ;______________________________________ Starting ground color
+		.byte 27 ;_______________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/backontrack.lz.bin" ; Size: 1399
+
+	sprite_data_explorers:	; Size: 1411
+		.incbin "EXPORTS/sprite/explorers.bin"
 	sprite_data_unity:	; Size: 1411
 		.incbin "EXPORTS/sprite/unity.bin"
 	sprite_data_dorabaebasic6:	; Size: 1401
 		.incbin "EXPORTS/sprite/dorabaebasic6.bin"
-	sprite_data_xx:	; Size: 1396
-		.incbin "EXPORTS/sprite/xx.bin"
+	sprite_data_sonar:	; Size: 1126
+		.incbin "EXPORTS/sprite/sonar.bin"
+	.align 8192
+
+
+; Data bank A8, total bank size: 7975 bytes
 	.export level_data_somewhereinaforest_0
 	level_data_somewhereinaforest_0:
 	; Level data
 		.incbin "EXPORTS/level/somewhereinaforest.lz.1.bin" ; Size: 1352
 
+	.export level_data_thetower
+	level_data_thetower:
+	; Header
+		.byte <sprite_data_thetower ;_________________ Sprite data ptr, low byte
+		.byte >(sprite_data_thetower) & $1F | $A0 ;___ Sprite data ptr, high byte
+		.byte <(sprite_data_thetower >> 13) ;_________ Sprite data bank
+		.byte song_desert_city ;______________________ Song ID
+		.byte (0 << 4) | 0 ;__________________________ Starting game mode and speed
+		.byte ($A0) ;_________________________________ Spawn Y Position (high byte)
+		.byte ($80) ;_________________________________ Y Scroll Position (low byte)
+		.byte (1 << 0) | (1 << 1) ;___________________ Force platformer, Disable parallax
+		.byte (1 << 7) | _EXTRASPRITES1 ;_____________ Max Fall Speed is 7?, Deco type
+		.byte (_SPIKESA << 4) | _BLOCKSB ;____________ Spike Set, Block Set
+		.byte $03 ;___________________________________ Starting background color
+		.byte $0F ;___________________________________ Starting ground color
+		.byte 32 ;____________________________________ Level height
+	; Level data
+		.incbin "EXPORTS/level/thetower.lz.bin" ; Size: 1324
+
+	sprite_data_slaughterhouse:	; Size: 1336
+		.incbin "EXPORTS/sprite/slaughterhouse.bin"
 	.export level_data_trolledfix
 	level_data_trolledfix:
 	; Header
@@ -4229,7 +4290,7 @@
 		.byte song_youve_been_trolled ;_________________ Song ID
 		.byte (0 << 4) | 0 ;____________________________ Starting game mode and speed
 		.byte ($B0) ;___________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;___________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;___________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_____________________ Force platformer, Disable parallax
 		.byte (0 << 7) | _DECO1 ;_______________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESC << 4) | _BLOCKSC ;______________ Spike Set, Block Set
@@ -4239,48 +4300,18 @@
 	; Level data
 		.incbin "EXPORTS/level/trolledfix.lz.bin" ; Size: 1315
 
-	.export level_data_xmaschallenge
-	level_data_xmaschallenge:
-	; Header
-		.byte <sprite_data_xmaschallenge ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_xmaschallenge) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_xmaschallenge >> 13) ;_________ Sprite data bank
-		.byte song_snow ;__________________________________ Song ID
-		.byte (0 << 4) | 0 ;_______________________________ Starting game mode and speed
-		.byte ($B0) ;______________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;______________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;________________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;__________________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_________________ Spike Set, Block Set
-		.byte $16 ;________________________________________ Starting background color
-		.byte $0F ;________________________________________ Starting ground color
-		.byte 27 ;_________________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/xmaschallenge.lz.bin" ; Size: 1263
-
+	sprite_data_hungrymanadventures:	; Size: 1321
+		.incbin "EXPORTS/sprite/hungrymanadventures.bin"
+	sprite_data_thetripletrial:	; Size: 1301
+		.incbin "EXPORTS/sprite/thetripletrial.bin"
 	.align 8192
 
 
-; Data bank A8, total bank size: 7531 bytes
-	sprite_data_hungrymanadventures:	; Size: 1321
-		.incbin "EXPORTS/sprite/hungrymanadventures.bin"
-	sprite_data_everymadness:	; Size: 1256
-		.incbin "EXPORTS/sprite/everymadness.bin"
-	sprite_data_jumper:	; Size: 1246
-		.incbin "EXPORTS/sprite/jumper.bin"
-	.export level_data_birdbrain_11
-	level_data_birdbrain_11:
-	; Level data
-		.incbin "EXPORTS/level/birdbrain.lz.1.bin" ; Size: 1241
-
+; Data bank A9, total bank size: 8101 bytes
 	sprite_data_dastardly:	; Size: 1236
 		.incbin "EXPORTS/sprite/dastardly.bin"
 	sprite_data_feather:	; Size: 1231
 		.incbin "EXPORTS/sprite/feather.bin"
-	.align 8192
-
-
-; Data bank A9, total bank size: 8187 bytes
 	sprite_data_ultiatedestruction:	; Size: 1226
 		.incbin "EXPORTS/sprite/ultiatedestruction.bin"
 	.export level_data_madness
@@ -4292,7 +4323,7 @@
 		.byte song_c_madness ;_______________________ Song ID
 		.byte (0 << 4) | 0 ;_________________________ Starting game mode and speed
 		.byte ($B0) ;________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;________________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;________________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;__________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;____________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;___________ Spike Set, Block Set
@@ -4304,39 +4335,22 @@
 
 	sprite_data_polargeist:	; Size: 1211
 		.incbin "EXPORTS/sprite/polargeist.bin"
-	.export level_data_thecellar
-	level_data_thecellar:
-	; Header
-		.byte <sprite_data_thecellar ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_thecellar) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_thecellar >> 13) ;_________ Sprite data bank
-		.byte song_scheming_weasel ;___________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (1 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (1 << 7) | _DECO1 ;______________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESA << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $1C ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 57 ;_____________________________________ Level height
-	; Level data
-		.incbin "EXPORTS/level/thecellar.lz.bin" ; Size: 1134
-
-	sprite_data_baseafterbase:	; Size: 1146
-		.incbin "EXPORTS/sprite/baseafterbase.bin"
-	sprite_data_sonar:	; Size: 1126
-		.incbin "EXPORTS/sprite/sonar.bin"
-	sprite_data_stereomadness:	; Size: 1111
-		.incbin "EXPORTS/sprite/stereomadness.bin"
+	sprite_data_aprettyeasylevel:	; Size: 1161
+		.incbin "EXPORTS/sprite/aprettyeasylevel.bin"
+	sprite_data_short_kings:	; Size: 816
+		.incbin "EXPORTS/sprite/short_kings.bin"
 	.align 8192
 
 
-; Data bank AA, total bank size: 8055 bytes
+; Data bank AA, total bank size: 8105 bytes
 	sprite_data_chromaticexpedition:	; Size: 1126
 		.incbin "EXPORTS/sprite/chromaticexpedition.bin"
+	sprite_data_stereomadness:	; Size: 1111
+		.incbin "EXPORTS/sprite/stereomadness.bin"
 	sprite_data_firetemple:	; Size: 1111
 		.incbin "EXPORTS/sprite/firetemple.bin"
+	sprite_data_shadowtemple:	; Size: 1101
+		.incbin "EXPORTS/sprite/shadowtemple.bin"
 	sprite_data_nullscapes:	; Size: 1101
 		.incbin "EXPORTS/sprite/nullscapes.bin"
 	.export level_data_chippe
@@ -4348,7 +4362,7 @@
 		.byte song_dry_out ;________________________ Song ID
 		.byte (0 << 4) | 0 ;________________________ Starting game mode and speed
 		.byte ($B0) ;_______________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;_______________________________ Y Scroll Position (low byte)
+		.byte ($CF) ;_______________________________ Y Scroll Position (low byte)
 		.byte (0 << 0) | (0 << 1) ;_________________ Force platformer, Disable parallax
 		.byte (1 << 7) | _DECO1 ;___________________ Max Fall Speed is 7?, Deco type
 		.byte (_SPIKESA << 4) | _BLOCKSA ;__________ Spike Set, Block Set
@@ -4358,20 +4372,24 @@
 	; Level data
 		.incbin "EXPORTS/level/chippe.lz.bin" ; Size: 1085
 
-	sprite_data_kappaclysm:	; Size: 1066
-		.incbin "EXPORTS/sprite/kappaclysm.bin"
-	sprite_data_dryout:	; Size: 1061
-		.incbin "EXPORTS/sprite/dryout.bin"
-	sprite_data_stalemate:	; Size: 1026
-		.incbin "EXPORTS/sprite/stalemate.bin"
-	sprite_data_xmaschallenge:	; Size: 466
-		.incbin "EXPORTS/sprite/xmaschallenge.bin"
+	sprite_data_leveleasy:	; Size: 1081
+		.incbin "EXPORTS/sprite/leveleasy.bin"
+	sprite_data_watertemple:	; Size: 376
+		.incbin "EXPORTS/sprite/watertemple.bin"
 	.align 8192
 
 
-; Data bank AB, total bank size: 6070 bytes
+; Data bank AB, total bank size: 8146 bytes
+	sprite_data_dryout:	; Size: 1061
+		.incbin "EXPORTS/sprite/dryout.bin"
+	sprite_data_groundtoretray:	; Size: 1041
+		.incbin "EXPORTS/sprite/groundtoretray.bin"
+	sprite_data_stalemate:	; Size: 1026
+		.incbin "EXPORTS/sprite/stalemate.bin"
 	sprite_data_wcropolix:	; Size: 1026
 		.incbin "EXPORTS/sprite/wcropolix.bin"
+	sprite_data_shardscapes:	; Size: 986
+		.incbin "EXPORTS/sprite/shardscapes.bin"
 	sprite_data_denouement:	; Size: 956
 		.incbin "EXPORTS/sprite/denouement.bin"
 	.export level_data_thesewers
@@ -4393,31 +4411,13 @@
 	; Level data
 		.incbin "EXPORTS/level/thesewers.lz.bin" ; Size: 940
 
-	sprite_data_kratos:	; Size: 906
-		.incbin "EXPORTS/sprite/kratos.bin"
-	sprite_data_cantletgo:	; Size: 856
-		.incbin "EXPORTS/sprite/cantletgo.bin"
-	.export level_data_luckydraw
-	level_data_luckydraw:
-	; Header
-		.byte <sprite_data_luckydraw ;_________________ Sprite data ptr, low byte
-		.byte >(sprite_data_luckydraw) & $1F | $A0 ;___ Sprite data ptr, high byte
-		.byte <(sprite_data_luckydraw >> 13) ;_________ Sprite data bank
-		.byte song_every_end_pt1 ;_____________________ Song ID
-		.byte (0 << 4) | 0 ;___________________________ Starting game mode and speed
-		.byte ($B0) ;__________________________________ Spawn Y Position (high byte)
-		.byte ($EF) ;__________________________________ Y Scroll Position (low byte)
-		.byte (0 << 0) | (1 << 1) ;____________________ Force platformer, Disable parallax
-		.byte (0 << 7) | _DECOCLOUD ;__________________ Max Fall Speed is 7?, Deco type
-		.byte (_SPIKESB << 4) | _BLOCKSB ;_____________ Spike Set, Block Set
-		.byte $0F ;____________________________________ Starting background color
-		.byte $0F ;____________________________________ Starting ground color
-		.byte 27 ;_____________________________________ Level height
+	sprite_data_backontrack:	; Size: 911
+		.incbin "EXPORTS/sprite/backontrack.bin"
+	.export level_data_motion_16
+	level_data_motion_16:
 	; Level data
-		.incbin "EXPORTS/level/luckydraw.lz.bin" ; Size: 684
+		.incbin "EXPORTS/level/motion.lz.1.bin" ; Size: 186
 
-	sprite_data_doubletripletrial:	; Size: 676
-		.incbin "EXPORTS/sprite/doubletripletrial.bin"
 	.align 8192
 
 

--- a/LEVELS/metadata/lvlset_A_metadata.json5
+++ b/LEVELS/metadata/lvlset_A_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [
@@ -45,7 +45,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			objectOffsets: [
 				{
@@ -1472,7 +1472,7 @@
             startingBackgroundColor: 0x03,
             startingGroundColor: 0x0F,
             spawnYPositionHi: 0xA0,
-            scrollYPositionLow: 0x80,
+            scrollYPosition: 0x0260,
 			forcePlatformer: true,
             parallaxDisable: true,
             maxFallSpeed_is_7: 0x01,
@@ -1506,7 +1506,7 @@
 			forcePlatformer: true,
 			parallaxDisable: true,
 			spawnYPositionHi: 0xA0,
-			scrollYPositionLow: 0x80,
+			scrollYPosition: 0x0260,
 			objectOffsets: [
 				{
 					coordinates: [15,38],
@@ -1572,7 +1572,7 @@
 			forcePlatformer: true,
 			parallaxDisable: true,
 			spawnYPositionHi: 0xb0,
-			scrollYPositionLow: 0xef,
+			scrollYPosition: 0x02CF,
 			objectOffsets: [
 				{
 					coordinates: [46,56],
@@ -1603,9 +1603,7 @@
 			parallaxDisable: true,
 			forcePlatformer: true,
 			spawnYPositionHi: 0x40,
-			spawnYPositionLow: 0x00,
-			scrollYPositionHi: 0x02,
-			scrollYPositionLow: 0xef,
+			scrollYPosition: 0x02CF,
 			objectOffsets: [
 				{
 					coordinates: [41,44],

--- a/LEVELS/metadata/lvlset_B_metadata.json5
+++ b/LEVELS/metadata/lvlset_B_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [

--- a/LEVELS/metadata/lvlset_C_metadata.json5
+++ b/LEVELS/metadata/lvlset_C_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [
@@ -1174,7 +1174,7 @@
 			startingBackgroundColor: 0x0C,
 			startingGroundColor: 0x0C,
 			spawnYPositionHi: 0x70,
-			scrollYPositionLow: 0x30,
+			scrollYPosition: 0x0210,
 			parallaxDisable: true,
 			objectOffsets: [
 				{

--- a/LEVELS/metadata/lvlset_D_metadata.json5
+++ b/LEVELS/metadata/lvlset_D_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [

--- a/LEVELS/metadata/lvlset_E_metadata.json5
+++ b/LEVELS/metadata/lvlset_E_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0210,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [

--- a/LEVELS/metadata/lvlset_HUGE_metadata.json5
+++ b/LEVELS/metadata/lvlset_HUGE_metadata.json5
@@ -17,7 +17,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0230,
 			maxFallSpeed_is_7: 0x01,
 			parallaxDisable: true,
 			objectOffsets: [
@@ -45,7 +45,7 @@
 			startingBackgroundColor: 0x12,
 			startingGroundColor: 0x02,
 			//spawnYPositionHi: 0x30,		;default #$B000
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0230,
 			maxFallSpeed_is_7: 0x01,
 			objectOffsets: [
 				{
@@ -1499,7 +1499,7 @@
             startingBackgroundColor: 0x03,
             startingGroundColor: 0x0F,
             spawnYPositionHi: 0xA0,
-            scrollYPositionLow: 0x80,
+            scrollYPosition: 0x0280,
             parallaxDisable: true,
             forcePlatformer: true,
             maxFallSpeed_is_7: 0x01,
@@ -1534,7 +1534,7 @@
 			parallaxDisable: true,
 			forcePlatformer: true,
 			spawnYPositionHi: 0xA0,
-			scrollYPositionLow: 0x80,
+			scrollYPosition: 0x0280,
 			objectOffsets: [
 				{
 					coordinates: [15,38],
@@ -1601,8 +1601,7 @@
 			parallaxDisable: true,
 			forcePlatformer: true,
 			spawnYPositionHi: 0xb0,
-			scrollYPositionHi: 0x02,
-			scrollYPositionLow: 0xef,
+			scrollYPosition: 0x02CF,
 			objectOffsets: [
 				{
 					coordinates: [46,56],
@@ -1633,9 +1632,7 @@
 			parallaxDisable: true,
 			forcePlatformer: true,
 			spawnYPositionHi: 0x40,
-			spawnYPositionLow: 0x00,
-			scrollYPositionHi: 0x02,
-			scrollYPositionLow: 0xef,
+			scrollYPosition: 0x02CF,
 			objectOffsets: [
 				{
 					coordinates: [41,44],
@@ -4772,7 +4769,7 @@
 			startingBackgroundColor: 0x0C,
 			startingGroundColor: 0x0C,
 			spawnYPositionHi: 0x70,
-			scrollYPositionLow: 0x30,
+			scrollYPosition: 0x0230,
 			parallaxDisable: true,
 			objectOffsets: [
 				{
@@ -7372,7 +7369,7 @@
 			stars: 10,
 			songID: "song_slow_down",
 			//spawnYPositionHi: 0x30,
-			//scrollYPositionLow: 0x30,
+			//scrollYPosition: 0x0230,
 			maxFallSpeed_is_7: 0x01,
 			startingGameMode: 4,
 			startingSpeed: 1,

--- a/LIB/asm/crt0.s
+++ b/LIB/asm/crt0.s
@@ -412,14 +412,11 @@ CURSED_MUSIC_ENABLE = 1
 .endif
 	.include "sfx.s"
 
-.segment "COLLMAP0"
+.segment "COLLMAP"
 	collMap0:		.res 16*15
-.segment "COLLMAP1"
 	collMap1:		.res 16*15
-.segment "COLLMAP2"
-    collMap2:       .res 16*15
-.segment "COLLMAP3"
-    collMap3:       .res 16*12
+	collMap2:		.res 16*15
+	collMap3:		.res 16*12
 	ground:			.res 16*3
 
 .segment "SRAM"

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -52,6 +52,25 @@ sprite_data = _sprite_data
 	jsr crossPRGBankJump
 .endmacro
 
+;__	AX = input, AX = output
+;
+;	The math behind this:
+;	Every time we pass the $100 boundary, we need to subtract $10.
+;	$100 is literally the upper byte, the amount of such transitions.
+;	Indeed, this works perfectly for any linear coordinate in
+;	the range 0..$FFF.
+;	In this case a table of shifting by 4 is used, which limits the
+;	total proper input value to $FFF.
+;
+;__	Writeup done in 2026 by dajinkosa
+.macro calculate_linear_scroll_y
+	SEC
+	SBC shiftBy4table, X
+	BCS :+
+		DEX
+	:
+.endmacro
+
 
 .segment "ZEROPAGE"
 	rld_value:      	.res 1
@@ -2041,34 +2060,6 @@ exit:
 	sty _sprite_data+1	;__	invalidate the sprite pointer
 early_exit:
 	rts
-.endproc
-
-
-; uint16_t calculate_linear_scroll_y(uint16_t nonlinearScroll);
-.segment "CODE_2"
-
-.export _calculate_linear_scroll_y
-.proc _calculate_linear_scroll_y
-	;__	AX = input, AX = output
-	;
-	;	The math behind this:
-	;	Every time we pass the $100 boundary, we need to subtract $10.
-	;	$100 is literally the upper byte, the amount of such transitions.
-	;	Indeed, this works perfectly for any linear coordinate in
-	;	the range 0..$FFF.
-	;	In this case a table of shifting by 4 is used, which limits the
-	;	total proper input value to $FFF.
-	;
-	;__	Writeup done in 2026 by dajinkosa
-	;
-	;	In fact this works so well this needs to be a macro instead lmao
-	;__
-	SEC
-	SBC shiftBy4table, X
-	BCS :+
-		DEX
-	:
-	RTS
 .endproc
 
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -2133,9 +2133,8 @@ sta _linear_scroll_y+1
     lda _sprite_data_bank
     jsr mmc3_set_prg_bank_1
 
-	lda	_scroll_y
-	ldx	_scroll_y+1
-	jsr _calculate_linear_scroll_y
+	lda	_linear_scroll_y
+	ldx	_linear_scroll_y+1
 	sta realScrollY
 	stx realScrollY+1
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -2058,38 +2058,23 @@ stx _linear_scroll_y+1
 .export _cap_scroll_y_at_bottom
 .proc _cap_scroll_y_at_bottom
 check:
-	lda     _scroll_y_subpx	;
-	cmp     #0              ;
-	lda     _scroll_y		;
-	sbc     #<$02F0			;	if (scroll_y > 0x2EF)
-	lda     _scroll_y+1		;
-	sbc     #>$02F0			;__
-	bcs     doit
+	sec							;
+	lda		_linear_scroll_y	;
+	sbc		#<$02CF				;	if (scroll_y > 0x2EF)
+	tay							;
+	lda		_linear_scroll_y+1	;
+	sbc		#>$02CF				;__
+	bpl		doit
 	rts
 
 doit:
-	; compensate currplayer_rely
-	ldx     _scroll_y
-	ldy     _scroll_y+1
+; LAZY LINEAR INSERT! (but role reversed)
+lda #<$02EF
+sta _scroll_y
+lda #>$02EF
+sta _scroll_y+1
 
-
-; LAZY LINEAR INSERT!
-lda #<$02CF	; the maximum scroll value, but linear
-sta _linear_scroll_y
-lda #>$02CF
-sta _linear_scroll_y+1
-
-	lda     #<$02EF			;
-	sta     sreg			;
-	sta     _scroll_y		;	scroll_y = 0x2EF
-	lda     #>$02EF			;
-	sta     sreg+1			;
-	sta     _scroll_y+1		;__
-
-	tya									;
-	jsr     __sub_scroll_y_ext			;	Get difference
-	jsr     _calculate_linear_scroll_y	;__
-	tay
+	;__	Notably, we can't do shit with the upper byte of the difference
 
 	lda     _currplayer_rely	;
 	clc							;
@@ -2111,7 +2096,6 @@ sta _linear_scroll_y+1
 
 	lda     #0
 	sta     _scroll_y_subpx
-	; we can't do anything with the high byte of the diff anyway
 
 	rts
 .endproc
@@ -2120,7 +2104,7 @@ sta _linear_scroll_y+1
 ; void check_spr_objects();
 .segment "CODE_2"
 
-.import _activesprites_active, _scroll_x, _scroll_y, _animating
+.import _activesprites_active, _scroll_x, _linear_scroll_y, _animating
 
 .export _check_spr_objects := check_spr_objects
 .proc check_spr_objects

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -2068,7 +2068,7 @@ doit:
 	sec							;
 	sbc     _scroll_y_subpx		;
 	sta     _currplayer_rely	;	Compensate currplayer_rely
-	sta		_player_rely+1		;	(Apparently guaranteed to be 0)
+	sta		_player_rely		;	(The player apparently guaranteed to be 1st)
 	tya							;
 	adc     _currplayer_rely+1	;
 	sta     _currplayer_rely+1	;
@@ -2108,28 +2108,35 @@ stx _linear_scroll_y+1
 .proc _cap_scroll_y_at_bottom
 check:
 	sec							;
-	lda		_linear_scroll_y	;
-	sbc		#<$02CF				;	if (scroll_y > 0x2EF)
+	lda     _linear_scroll_y	;
+	sbc     #<$02CF				;	if (scroll_y > 0x2EF)
 	tay							;
-	lda		_linear_scroll_y+1	;
-	sbc		#>$02CF				;__
-	bpl		doit
+	lda     _linear_scroll_y+1	;
+	sbc     #>$02CF				;__
+	bpl     adjust
 	rts
 
-doit:
+adjust:
 ; LAZY LINEAR INSERT! (but role reversed)
 lda #<$02EF
 sta _scroll_y
 lda #>$02EF
 sta _scroll_y+1
 
-	;__	Notably, we can't do shit with the upper byte of the difference
+	;	Notably, we can't do shit with the upper byte of the difference
+	;__	Therefore it's OK to use the A
+
+
+	lda     #<$02CF				;
+	sta     _linear_scroll_y	;
+	lda     #>$02CF				;
+	sta     _linear_scroll_y+1	;__
 
 	lda     _currplayer_rely	;
 	clc							;
 	adc     _scroll_y_subpx		;
 	sta     _currplayer_rely	;	Compensate currplayer_rely
-	sta		_player_rely+1		;	(Apparently guaranteed to be 0)
+	sta     _player_rely		;	(The player apparently guaranteed to be 1st)
 	tya							;
 	adc     _currplayer_rely+1	;
 	sta     _currplayer_rely+1	;

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -381,23 +381,22 @@ _init_rld:
 	STA	extceil			;__
 
 	@min_scroll_y_calc:
-		LDA	#$00			;
-		STA	min_scroll_y+1	;__
-		
 		TXA						;
 		EOR	#$FF				;	Get 57 - level height
 		; SEC done by LDA #$01	;	aka the highest row
 		ADC #<(1+57-1)			;__
-		SEC
-	@min_scroll_y_loop:
-		TAX
-		SBC	#15				;__
-		BCC	@min_scroll_y_fin
-		INC	min_scroll_y+1
-		BCS	@min_scroll_y_loop	; = BRA
-	@min_scroll_y_fin:
-		LDA	shiftBy4table, X
-		ORA #$08
+
+		;__	Shift right by 4
+		SEC		;	ORA #$08 right away
+		ROL		;	These 2 are painless since
+		ASL		;__	our current height is always less than 64
+		;__	Y is zero, and won't be used anymore anyway
+		ASL
+		BCC :+
+			INY
+		:	STY	min_scroll_y+1	;__	Y is 0 or 1
+		ASL
+		ROL	min_scroll_y+1
 		STA min_scroll_y
 
 	incw ptr1
@@ -2037,36 +2036,31 @@ early_exit:
 .segment _SCROLL_BANK
 
 .importzp _currplayer_rely
-.import _scroll_y, _player_rely, _scroll_y_subpx
+.import _linear_scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_top
 .proc _cap_scroll_y_at_top
 check:
-	lda     _scroll_y		;
-	cmp     _min_scroll_y	;	if (scroll_y < min_scroll_y)
-	lda     _scroll_y+1		;
-	sbc     _min_scroll_y+1	;__
-	bcc     doit
+	lda     _linear_scroll_y	;
+	sec							;
+	sbc     _min_scroll_y		;	if (scroll_y < min_scroll_y)
+	tay							;
+	lda     _linear_scroll_y+1	;
+	sbc     _min_scroll_y+1		;__
+	bmi     doit
 	rts
 
 doit:
-	; compensate currplayer_rely and player_rely
-	lda     _scroll_y
-	ldx     _scroll_y+1
-	sta     sreg
-	stx     sreg+1
-	ldx     _min_scroll_y	;
-	lda     _min_scroll_y+1	;	scroll_y = min_scroll_y
-	stx     _scroll_y		;
-	sta     _scroll_y+1		;__
-	jsr     __sub_scroll_y_ext
-	jsr     _calculate_linear_scroll_y
-	eor     #$FF			;__	Make the ADCs into SBCs
-	tay
+	lda     _min_scroll_y
+	sta     _linear_scroll_y
+	lda     _min_scroll_y+1
+	sta     _linear_scroll_y+1
+
+	;__	Notably, we can't do shit with the upper byte of the difference
 
 	lda     _currplayer_rely	;
-	sec							;
-	sbc     _scroll_y_subpx		;
+	clc							;
+	adc     _scroll_y_subpx		;
 	sta     _currplayer_rely	;	Compensate currplayer_rely
 	sta		_player_rely		;	(The player apparently guaranteed to be 1st)
 	tya							;
@@ -2075,8 +2069,8 @@ doit:
 	sta     _player_rely+1		;__
 
 	lda     _player_rely+2		;
-	sec							;
-	sbc     _scroll_y_subpx		;
+	clc							;
+	adc     _scroll_y_subpx		;
 	sta     _player_rely+2		;	Compensate player_rely[1]
 	tya							;
 	adc     _player_rely+2+1	;
@@ -2085,12 +2079,12 @@ doit:
 	lda     #0
 	sta     _scroll_y_subpx
 
-; LAZY LINEAR INSERT!
-lda _scroll_y
-ldx _scroll_y+1
-jsr _calculate_linear_scroll_y
-sta _linear_scroll_y
-stx _linear_scroll_y+1
+; LAZY LINEAR INSERT! (but role reversed)
+lda _linear_scroll_y
+ldx _linear_scroll_y+1
+jsr _calculate_ppufmt_scroll_y
+sta _scroll_y
+stx _scroll_y+1
 
 	; we can't do anything with the high byte of the diff anyway
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1994,22 +1994,25 @@ early_exit:
 
 .export _calculate_linear_scroll_y
 .proc _calculate_linear_scroll_y
-	; AX = input, AX = output
-	; clobbers tmp1
-	STX tmp1
-	LDY	tmp1
-	INY	; for the BEQ ending condition
-	LDX #0
-	CLC
-	loop:
-		DEY
-		BEQ end
-		ADC #$F0
-		BCC loop
-			INX
-			CLC
-			BCC loop
-	end:
+	;__	AX = input, AX = output
+	;
+	;	The math behind this:
+	;	Every time we pass the $100 boundary, we need to subtract $10.
+	;	$100 is literally the upper byte, the amount of such transitions.
+	;	Indeed, this works perfectly for any linear coordinate in
+	;	the range 0..$FFF.
+	;	In this case a table of shifting by 4 is used, which limits the
+	;	total proper input value to $FFF.
+	;
+	;__	Writeup done in 2026 by dajinkosa
+	;
+	;	In fact this works so well this needs to be a macro instead lmao
+	;__
+	SEC
+	SBC shiftBy4table, X
+	BCS :+
+		DEX
+	:
 	RTS
 .endproc
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1999,19 +1999,12 @@ early_exit:
 	;	a very good estimate of the amount of such transitions.
 	;	With an adjustment at the end if the low byte >= $F0.
 	;	Indeed, this works perfectly for any linear coordinate in
-	;	the range 0..$E1F, as their (literal non-adjusted) outputs
-	;	are under $F00 (though, notably, $E10..$E1F actually maps
-	;	to $F00..$F0F due to the aforementioned adjustments).
+	;	the range 0..$FFF.
 	;	As of writing this in Summer of 2026, this fine game of Famidash
-	;	doesn't seem to need such values of Scroll Y, but the adjustment
-	;	is quite easy regardless! For any 15 (post-conversion but pre-adjustment)
-	;	high increments there is an additional #$10 added to the total value.
-	;	In environments with extreme Y scrolling needs this can be done
-	;	as a post-factor loop.
+	;	doesn't seem to need such values of Scroll Y, but we gotta have
+	;	future-proof code.
 	;	In this case a table of shifting by 4 is used, which limits the
-	;	total proper input value to $FFF anyway, therefore locked behind
-	;	the preprocessor for potential use lies the one-time adjuster if
-	;	the input value exceeds $E1F.
+	;	total proper input value to $FFF.
 	;
 	;__	Writeup done in 2026 by dajinkosa
 
@@ -2019,20 +2012,12 @@ early_exit:
 	CLC						;
 	ADC shiftBy4table, X	;
 	BCC :+					;	Do the addition
-		INX					;
+		INX					;__
+		ADC	#15	;__	C set	;
+		BCC :+				;	Compensate if we
+			INX				;	got too big
 	:						;__
 
-	;	This can be used to extend the range of input values
-	;	from	$000..$E1F (linear) / $0000..$0F0F (PPU fmt)
-	;	to		$000..$FFF (linear) / $0000..$110F (PPU fmt)
-	.if 0
-		CPX #15
-		BCC :+
-			ADC #15	;__	Carry is set
-			BCC	:+
-				INX
-		:
-	.endif
 
 	;__	Adjust the low byte for proper PPU format
 	CMP #$F0

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1250,7 +1250,7 @@ ntAddrHiTbl:
 ; [Subroutine]
 .global metatiles_top_left, metatiles_top_right, metatiles_bot_left, metatiles_bot_right
 .import _no_parallax, _invisblocks, _force_platformer
-.import _scroll_y
+.import _linear_scroll_y
 
 .proc draw_screen_UD_tiles_frame0
 	scroll_direction = tmp1
@@ -2109,13 +2109,6 @@ doit:
 	lda     #0
 	sta     _scroll_y_subpx
 
-; LAZY LINEAR INSERT! (but role reversed)
-lda _linear_scroll_y
-ldx _linear_scroll_y+1
-jsr _calculate_ppufmt_scroll_y
-sta _scroll_y
-stx _scroll_y+1
-
 	; we can't do anything with the high byte of the diff anyway
 
 	rts
@@ -2126,7 +2119,7 @@ stx _scroll_y+1
 .segment _SCROLL_BANK
 
 .importzp _currplayer_rely
-.import _scroll_y, _player_rely, _scroll_y_subpx
+.import _linear_scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_bottom
 .proc _cap_scroll_y_at_bottom
@@ -2141,11 +2134,6 @@ check:
 	rts
 
 adjust:
-; LAZY LINEAR INSERT! (but role reversed)
-lda #<$02EF
-sta _scroll_y
-lda #>$02EF
-sta _scroll_y+1
 
 	;	Notably, we can't do shit with the upper byte of the difference
 	;__	Therefore it's OK to use the A

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -3529,8 +3529,6 @@ drawplayer_common := _drawplayerone::common
 	; temp_x for X
 	; temp_y for Y
     LDA _temp_y     ;
-    CMP #$F0        ;   if(temp_y >= 0xf0) return 0;
-    BCS Return0		;__
     AND #$F0        ;	temp_y & 0xF0
     STA tmp1        ;__
 	LDA _temp_x		;
@@ -3548,20 +3546,11 @@ drawplayer_common := _drawplayerone::common
 	LDA #$00
 	STA ptr1
 
-	.if USE_ILLEGAL_OPCODES
-		LAX (ptr1),Y
-	.else
-		LDA (ptr1),Y
-		TAX
-	.endif
+	LDA (ptr1),Y
+	TAX
 	LDA metatiles_coll,X	;	return is_solid[collision];
 	STA _collision	;
 	RTS				;__
-
-	Return0:
-	LDA #$00
-	sta _collision
-	RTS
 
 .endproc
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -772,28 +772,28 @@ frame1:
 
 calc_seam_pos:
 
-	LDA ppufmt_seam_scroll_y
-	LDX ppufmt_seam_scroll_y+1
+	LDA seam_scroll_y
+	LDX seam_scroll_y+1
 
 	LDY	#15+15	;__	Load the starting nametable into Y
 
-	CPX #$02	;	If there is a seam,
-	BCS @noseam	;__	calculate its position in metatiles
+	BIT seam_absent	;	If there is a seam,
+	BMI @noseam		;__	calculate its position in metatiles
 	@yesseam:
-		LSR					;
-		LSR					;	Divide by 16, get index 
-		LSR					;	inside screen in metatiles
-		LSR					;__
-		CLC					;	Add 0 or 15, since scroll_y is nonlinear
-		ADC SeamTable, X	;__
-		ADC #30				;__	If the carry was set then something got fucked
+		LSR						;
+		LSR						;	Divide by 16, get index
+		LSR						;	inside screen in metatiles
+		LSR						;__
+		CLC						;	Add 0 or 16, since we're using the linear value
+		ADC shiftBy4table, X	;__
+		ADC #30					;__	If the carry was set then something got fucked
 		STA SeamValue
 		BCC @fin	; = BRA, unless the additions got fucked
 
 	@noseam:		;__	If there is no seam, store an invalid value
 		STX SeamValue
-		CPX	#$FF	;
-		BNE	@fin	;	If the starting screen is 0, load into Y
+		CPX	#$00	;
+		BPL	@fin	;	If the starting screen is 0, load into Y
 			LDY #0	;__
 	@fin:
 		STY	CurrentRow
@@ -1026,9 +1026,6 @@ ParallaxBuffer:
 		.byte $84, $94, $a4, $b4, $8a, $9a, $aa, $ba, $9d
 	ParallaxBufferCol5:
 		.byte $85, $95, $a5, $b5, $8b, $9b, $ab, $bb, $9e
-
-SeamTable:
-	.byte 0, 15
 
 ntAddrHiTbl:
 	.byte	$24|$80,	$20|$80

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -71,8 +71,8 @@ sprite_data = _sprite_data
 
 	; variables related to both the above and below
 	old_draw_scroll_y:		.res 2
-	seam_scroll_y:			.res 2
-	ppufmt_seam_scroll_y:	.res 2
+	seam_position:			.res 2
+	seam_position_screen:	.res 1	;__	High byte of seam_screen in PPU format, unless it's negative
 	seam_absent:			.res 1	;__	Only for its bit 7
 	
 	; variables related to draw_screen
@@ -89,8 +89,8 @@ sprite_data = _sprite_data
 
 .export _extceil := extceil
 .export _min_scroll_y := min_scroll_y
-.export	_seam_scroll_y := seam_scroll_y
-.export	_ppufmt_seam_scroll_y := ppufmt_seam_scroll_y
+.export	_seam_position := seam_position
+.export	_seam_position_screen := seam_position_screen
 .export _seam_absent := seam_absent
 .export _old_draw_scroll_y := old_draw_scroll_y
 
@@ -772,8 +772,8 @@ frame1:
 
 calc_seam_pos:
 
-	LDA seam_scroll_y
-	LDX seam_scroll_y+1
+	LDA seam_position
+	LDX seam_position+1
 
 	LDY	#15+15	;__	Load the starting nametable into Y
 
@@ -1072,7 +1072,7 @@ ntAddrHiTbl:
 	.endif
 
 	;	Seam pos for attributes:
-	;	( <seam_scroll_y & $E0 | >seam_scroll_y & 1 | (seam present ? 0 : 2)) ^
+	;	( <seam_position & $E0 | >seam_position & 1 | (seam present ? 0 : 2)) ^
 	;__	^ (column & $0E) - $20
 	;	Bits 7-4 define the row where the seam switch occurs
 	;	Bit 0 defines when the seam is activated:
@@ -1089,8 +1089,8 @@ ntAddrHiTbl:
 	;	Unfortunately the seam requires every two rows and is attached to ppufmt,
 	;__	so we convert to ppufmt to get which screen we are on
 
-	LDA seam_scroll_y					;
-	LDX	seam_scroll_y+1					;
+	LDA seam_position					;
+	LDX	seam_position+1					;
 	TAY									;
 	BMI	:+								;	Calculate the ppufmt seam if positive
 		JSR _calculate_ppufmt_scroll_y	;
@@ -1110,7 +1110,7 @@ ntAddrHiTbl:
 	LDY	#>collMap2			;	Load the default
 	LDX	#(<collMap2>>4)		;__	starting position
 
-	LDA seam_scroll_y+1		;
+	LDA seam_position+1		;
 	BPL :+					;	If starting at screen 0,
 		LDY #>collMap0		;	load starting position of screen 0
 		LDX #(<collMap0>>4)	;__
@@ -1329,8 +1329,8 @@ ntAddrHiTbl:
 
 	calc_new_seam_pos:
 		@start:
-			LDA	seam_scroll_y
-			LDX	seam_scroll_y+1
+			LDA	seam_position
+			LDX	seam_position+1
 			CPY	#$00	;	Always sets carry
 			BMI	@up		;__
 		
@@ -1392,16 +1392,15 @@ ntAddrHiTbl:
 
 			LDA	new_seam_pos
 			LDX	new_seam_pos+1
-			STA	seam_scroll_y
-			STX seam_scroll_y+1
+			STA	seam_position
+			STX seam_position+1
 
 			;	Unfortunately, the calculations require
 			;__	the seam location to be in PPU format.
 			BMI	@seam_pos_negative_skip			;	Get new_seam_pos in PPU format
 				JSR	_calculate_ppufmt_scroll_y	;	If the seam is negative, it doesn't matter much
 			@seam_pos_negative_skip:			;__
-			STA	ppufmt_seam_scroll_y			;	Store the next frames' PPU format seam position
-			STX	ppufmt_seam_scroll_y+1			;__
+			STX	seam_position_screen			;__	Store the next frames' seam position screen (PPU format)
 			CPX	#$02							;	Only the bit 7 of seam_absent matters
 			ROR	seam_absent						;__
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -4,9 +4,6 @@
 .import pusha, pushax, callptr4
 .import _scroll_x, _cursedmusic
 
-; LAZY LINEAR INSERT!
-.import _linear_scroll_y
-
 .if VS_SYSTEM
 	.import _draw_arrow
 .endif
@@ -1250,7 +1247,7 @@ ntAddrHiTbl:
 ; [Subroutine]
 .global metatiles_top_left, metatiles_top_right, metatiles_bot_left, metatiles_bot_right
 .import _no_parallax, _invisblocks, _force_platformer
-.import _linear_scroll_y
+.import _scroll_y
 
 .proc draw_screen_UD_tiles_frame0
 	scroll_direction = tmp1
@@ -1270,13 +1267,13 @@ ntAddrHiTbl:
 	SepWriEnd = Separate2WritesSize
 
 	start:
-		LDA	_linear_scroll_y		;
-		SEC							;
-		SBC	old_draw_scroll_y		;
-		STA	tmp1					;	XY = scroll_y - old_draw_scroll_y
-		LDA	_linear_scroll_y+1		;
-		SBC	old_draw_scroll_y+1		;
-		TAY							;__
+		LDA	_scroll_y			;
+		SEC						;
+		SBC	old_draw_scroll_y	;
+		STA	tmp1				;	XY = scroll_y - old_draw_scroll_y
+		LDA	_scroll_y+1			;
+		SBC	old_draw_scroll_y+1	;
+		TAY						;__
 
 		ORA	tmp1
 		BNE	calc_new_seam_pos
@@ -1297,20 +1294,20 @@ ntAddrHiTbl:
 			BCC :+
 				INX
 			:
-			STA	this_seam_pos+0		;	Store new seam position
-			STX	this_seam_pos+1		;__
-			STA	new_seam_pos		;	Store new seam position
-			STX	new_seam_pos+1		;__
-			SEC						;
-			EOR	#$FF				;
-			ADC	_linear_scroll_y	;	Calculate the difference
-			TAY						;	between scroll_y and seam position
-			LDA	_linear_scroll_y+1	;
-			SBC	new_seam_pos+1		;__
-			CPY	#($78 - $40)		;	If the difference is less than
-			LDY	#2					;	($78 - $40), we went too far
-			SBC	#$00				;	Also load the scrolling direction offset
-			BPL	@fin				;__
+			STA	this_seam_pos+0	;	Store new seam position
+			STX	this_seam_pos+1	;__
+			STA	new_seam_pos	;	Store new seam position
+			STX	new_seam_pos+1	;__
+			SEC					;
+			EOR	#$FF			;
+			ADC	_scroll_y		;	Calculate the difference
+			TAY					;	between scroll_y and seam position
+			LDA	_scroll_y+1		;
+			SBC	new_seam_pos+1	;__
+			CPY	#($78 - $40)	;	If the difference is less than
+			LDY	#2				;	($78 - $40), we went too far
+			SBC	#$00			;	Also load the scrolling direction offset
+			BPL	@fin			;__
 		
 		@ret0:		;
 			LDA	#0	;	Return 0
@@ -1326,24 +1323,24 @@ ntAddrHiTbl:
 				DEX
 				SEC
 			:
-			STA	new_seam_pos		;	Store new seam position
-			STX	new_seam_pos+1		;__
-			;__	Carry set previously;
-			EOR	#$FF				;
-			ADC	_linear_scroll_y	;	Calculate the difference
-			TAY						;	between scroll_y and seam position
-			LDA	_linear_scroll_y+1	;
-			SBC	new_seam_pos+1		;__
-			CPY	#($78 + $40)		;	If the difference is more than
-			LDY	#0					;	($78 + $40), we went too far
-			SBC	#$00				;	Also load scrolling direction offset
-			BPL	@ret0				;__
+			STA	new_seam_pos	;	Store new seam position
+			STX	new_seam_pos+1	;__
+			;__	Carry set previously
+			EOR	#$FF			;
+			ADC	_scroll_y		;	Calculate the difference
+			TAY					;	between scroll_y and seam position
+			LDA	_scroll_y+1		;
+			SBC	new_seam_pos+1	;__
+			CPY	#($78 + $40)	;	If the difference is more than
+			LDY	#0				;	($78 + $40), we went too far
+			SBC	#$00			;	Also load scrolling direction offset
+			BPL	@ret0			;__
 		
 		@fin:
 			STY	scroll_direction
 
-			LDA	_linear_scroll_y
-			LDX	_linear_scroll_y+1
+			LDA	_scroll_y
+			LDX	_scroll_y+1
 			STA	old_draw_scroll_y
 			STX	old_draw_scroll_y+1
 
@@ -2066,25 +2063,25 @@ early_exit:
 .segment _SCROLL_BANK
 
 .importzp _currplayer_rely
-.import _linear_scroll_y, _player_rely, _scroll_y_subpx
+.import _scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_top
 .proc _cap_scroll_y_at_top
 check:
-	lda     _linear_scroll_y	;
-	sec							;
-	sbc     _min_scroll_y		;	if (scroll_y < min_scroll_y)
-	tay							;
-	lda     _linear_scroll_y+1	;
-	sbc     _min_scroll_y+1		;__
+	lda     _scroll_y		;
+	sec						;
+	sbc     _min_scroll_y	;	if (scroll_y < min_scroll_y)
+	tay						;
+	lda     _scroll_y+1		;
+	sbc     _min_scroll_y+1	;__
 	bmi     doit
 	rts
 
 doit:
 	lda     _min_scroll_y
-	sta     _linear_scroll_y
+	sta     _scroll_y
 	lda     _min_scroll_y+1
-	sta     _linear_scroll_y+1
+	sta     _scroll_y+1
 
 	;__	Notably, we can't do shit with the upper byte of the difference
 
@@ -2119,17 +2116,17 @@ doit:
 .segment _SCROLL_BANK
 
 .importzp _currplayer_rely
-.import _linear_scroll_y, _player_rely, _scroll_y_subpx
+.import _scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_bottom
 .proc _cap_scroll_y_at_bottom
 check:
-	sec							;
-	lda     _linear_scroll_y	;
-	sbc     #<$02CF				;	if (scroll_y > 0x2EF)
-	tay							;
-	lda     _linear_scroll_y+1	;
-	sbc     #>$02CF				;__
+	sec					;
+	lda     _scroll_y	;
+	sbc     #<$02CF		;	if (scroll_y > 0x2EF[ppu fmt])
+	tay					;
+	lda     _scroll_y+1	;
+	sbc     #>$02CF		;__
 	bpl     adjust
 	rts
 
@@ -2140,9 +2137,9 @@ adjust:
 
 
 	lda     #<$02CF				;
-	sta     _linear_scroll_y	;
+	sta     _scroll_y			;
 	lda     #>$02CF				;
-	sta     _linear_scroll_y+1	;__
+	sta     _scroll_y+1			;__
 
 	lda     _currplayer_rely	;
 	clc							;
@@ -2172,7 +2169,7 @@ adjust:
 ; void check_spr_objects();
 .segment "CODE_2"
 
-.import _activesprites_active, _scroll_x, _linear_scroll_y, _animating
+.import _activesprites_active, _scroll_x, _scroll_y, _animating
 
 .export _check_spr_objects := check_spr_objects
 .proc check_spr_objects
@@ -2185,8 +2182,8 @@ adjust:
     lda _sprite_data_bank
     jsr mmc3_set_prg_bank_1
 
-	lda	_linear_scroll_y
-	ldx	_linear_scroll_y+1
+	lda	_scroll_y
+	ldx	_scroll_y+1
 	sta realScrollY
 	stx realScrollY+1
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -73,6 +73,7 @@ sprite_data = _sprite_data
 	old_draw_scroll_y:		.res 2
 	seam_scroll_y:			.res 2
 	ppufmt_seam_scroll_y:	.res 2
+	seam_absent:			.res 1	;__	Only for its bit 7
 	
 	; variables related to draw_screen
 	rld_column:			.res 1
@@ -90,6 +91,7 @@ sprite_data = _sprite_data
 .export _min_scroll_y := min_scroll_y
 .export	_seam_scroll_y := seam_scroll_y
 .export	_ppufmt_seam_scroll_y := ppufmt_seam_scroll_y
+.export _seam_absent := seam_absent
 .export _old_draw_scroll_y := old_draw_scroll_y
 
 .export _drawing_frame := drawing_frame
@@ -1351,21 +1353,25 @@ ntAddrHiTbl:
 
 			;	Unfortunately, the calculations require
 			;__	the seam location to be in PPU format.
-			LDA	this_seam_pos				;
-			LDX	this_seam_pos+1				;
-			JSR	_calculate_ppufmt_scroll_y	;	Get this_seam_pos in PPU format
-			STA	this_seam_pos				;
-			STX	this_seam_pos+1				;__
-			LDY scroll_direction			;
-			BNE :+							;	If scroll_direction equals 2 (going down),
-				sec							;	new_seam_pos is equal to this_seam_pos
-				sbc #$10					;	But if scroll_direction equals 0 (going up),
-				bcs :+						;	new_seam_pos is equal to this_seam_pos - $10
-					sbc #15					;	(this is just the sub_scroll_y code verbatim,
-					dex						;	the fastest way to get to PPU fmt in this case)
-			:								;__
-			STA	ppufmt_seam_scroll_y		;	Store the next frames' PPU format seam position
-			STX	ppufmt_seam_scroll_y+1		;__
+			LDA	this_seam_pos					;
+			LDX	this_seam_pos+1					;	If the seam is negative, it doesn't matter much
+			BMI	@seam_pos_negative_skip			;__
+				JSR	_calculate_ppufmt_scroll_y	;	Get this_seam_pos in PPU format
+			@seam_pos_negative_skip:			;
+			STA	this_seam_pos					;
+			STX	this_seam_pos+1					;__
+			LDY scroll_direction				;
+			BNE :+								;	If scroll_direction equals 2 (going down),
+				sec								;	new_seam_pos is equal to this_seam_pos
+				sbc #$10						;	But if scroll_direction equals 0 (going up),
+				bcs :+							;	new_seam_pos is equal to this_seam_pos - $10
+					sbc #15						;	(this is just the sub_scroll_y code verbatim,
+					dex							;	the fastest way to get to PPU fmt in this case)
+			:									;__
+			STA	ppufmt_seam_scroll_y			;	Store the next frames' PPU format seam position
+			STX	ppufmt_seam_scroll_y+1			;__
+			CPX	#$02							;	Only the bit 7 of seam_absent matters
+			ROR	seam_absent						;__
 
 			LDY	this_seam_pos+1		;
 			CPY	#$02				;	If no seam, exit early

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1959,6 +1959,7 @@ early_exit:
 	rts
 .endproc
 
+
 ; uint16_t calculate_linear_scroll_y(uint16_t nonlinearScroll);
 .segment "CODE_2"
 
@@ -1982,6 +1983,69 @@ early_exit:
 	end:
 	RTS
 .endproc
+
+
+; uint16_t calculate_ppufmt_scroll_y(uint16_t linearScroll);
+.segment "CODE_2"
+
+.export _calculate_ppufmt_scroll_y
+.proc _calculate_ppufmt_scroll_y
+	;__	AX = input, AX = output
+
+	;
+	;	The math behind this:
+	;	Every time we pass the $F0 boundary, we need to add $10.
+	;	$F0 is extremely close to $100, so we can the upper byte as
+	;	a very good estimate of the amount of such transitions.
+	;	With an adjustment at the end if the low byte >= $F0.
+	;	Indeed, this works perfectly for any linear coordinate in
+	;	the range 0..$E1F, as their (literal non-adjusted) outputs
+	;	are under $F00 (though, notably, $E10..$E1F actually maps
+	;	to $F00..$F0F due to the aforementioned adjustments).
+	;	As of writing this in Summer of 2026, this fine game of Famidash
+	;	doesn't seem to need such values of Scroll Y, but the adjustment
+	;	is quite easy regardless! For any 15 (post-conversion but pre-adjustment)
+	;	high increments there is an additional #$10 added to the total value.
+	;	In environments with extreme Y scrolling needs this can be done
+	;	as a post-factor loop.
+	;	In this case a table of shifting by 4 is used, which limits the
+	;	total proper input value to $FFF anyway, therefore locked behind
+	;	the preprocessor for potential use lies the one-time adjuster if
+	;	the input value exceeds $E1F.
+	;
+	;__	Writeup done in 2026 by dajinkosa
+
+	;__	X already contains the high byte.
+	CLC						;
+	ADC shiftBy4table, X	;
+	BCC :+					;	Do the addition
+		INX					;
+	:						;__
+
+	;	This can be used to extend the range of input values
+	;	from	$000..$E1F (linear) / $0000..$0F0F (PPU fmt)
+	;	to		$000..$FFF (linear) / $0000..$110F (PPU fmt)
+	.if 0
+		CPX #15
+		BCC :+
+			ADC #15	;__	Carry is set
+			BCC	:+
+				INX
+		:
+	.endif
+
+	;__	Adjust the low byte for proper PPU format
+	CMP #$F0
+	BCC :+
+		ADC #15	;__	Carry is set
+		BCC	:+
+			INX
+	:
+
+	;__	We're all set!
+	RTS
+.endproc
+
 
 .if !__THE_ALBUM
 ; void cap_scroll_y_at_top();

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1286,21 +1286,29 @@ ntAddrHiTbl:
 
 	calc_new_seam_pos:
 		@start:
-			LDA	#$10
-			STA	sreg+0
-			LDA	ppufmt_seam_scroll_y
-			LDX	ppufmt_seam_scroll_y+1
-			CPY	#$00	;	Puts carry into X
+			LDA	seam_scroll_y
+			LDX	seam_scroll_y+1
+			CPY	#$00	;	Always sets carry
 			BMI	@up		;__
 		
 		@down:
-			JSR	__add_scroll_y		;__	Calculate new seam position
+			;__	Carry is set
+			ADC	#$10-1
+			BCC :+
+				INX
+			:
 			STA	this_seam_pos+0		;	Store new seam position
 			STX	this_seam_pos+1		;__
-			JSR	@calc_diff			;__	Calculate difference
-			CMP	#$38				;
-			TXA						;	If the difference is less than
-			LDX	#2					;	($78 - $40), we went too far
+			STA	new_seam_pos		;	Store new seam position
+			STX	new_seam_pos+1		;__
+			SEC						;
+			EOR	#$FF				;
+			ADC	_linear_scroll_y	;	Calculate the difference
+			TAY						;	between scroll_y and seam position
+			LDA	_linear_scroll_y+1	;
+			SBC	new_seam_pos+1		;__
+			CPY	#($78 - $40)		;	If the difference is less than
+			LDY	#2					;	($78 - $40), we went too far
 			SBC	#$00				;	Also load the scrolling direction offset
 			BPL	@fin				;__
 		
@@ -1308,41 +1316,61 @@ ntAddrHiTbl:
 			LDA	#0	;	Return 0
 			TAX		;	(nothing was done)
 			RTS		;__
-		
-		@calc_diff:	;__	[Subroutine]
-			STA	new_seam_pos		;	Store new seam position
-			STX	new_seam_pos+1		;__
-			STA	sreg+0				;
-			STX	sreg+1				;	Calculate the difference 
-			LDX	_scroll_y			;	between scroll_y and seam position
-			LDA	_scroll_y+1			;	(doesn't need to be linearized due to its indended range)
-			JMP	__sub_scroll_y_ext	;__
-		
+
 		@up:
+			;__	Carry is set
 			STA	this_seam_pos+0		;	Store old seam position
 			STX	this_seam_pos+1		;__
-			JSR	__sub_scroll_y		;__	Calculate new seam position
-			JSR	@calc_diff			;__	Calculate difference
-			CMP	#$B8				;
-			TXA						;	If the difference is more than
-			LDX	#0					;	($78 + $40), we went too far
+			SBC	#$10
+			BCS :+
+				DEX
+				SEC
+			:
+			STA	new_seam_pos		;	Store new seam position
+			STX	new_seam_pos+1		;__
+			;__	Carry set previously;
+			EOR	#$FF				;
+			ADC	_linear_scroll_y	;	Calculate the difference
+			TAY						;	between scroll_y and seam position
+			LDA	_linear_scroll_y+1	;
+			SBC	new_seam_pos+1		;__
+			CPY	#($78 + $40)		;	If the difference is more than
+			LDY	#0					;	($78 + $40), we went too far
 			SBC	#$00				;	Also load scrolling direction offset
 			BPL	@ret0				;__
 		
 		@fin:
-			STX	scroll_direction
+			STY	scroll_direction
 
 			LDA	_linear_scroll_y
-			LDY	_linear_scroll_y+1
+			LDX	_linear_scroll_y+1
 			STA	old_draw_scroll_y
-			STY	old_draw_scroll_y+1
+			STX	old_draw_scroll_y+1
 
 			LDA	new_seam_pos
-			LDY	new_seam_pos+1
-			STA	ppufmt_seam_scroll_y
-			STY	ppufmt_seam_scroll_y+1
+			LDX	new_seam_pos+1
+			STA	seam_scroll_y
+			STX seam_scroll_y+1
 
-			LDY	this_seam_pos+1
+			;	Unfortunately, the calculations require
+			;__	the seam location to be in PPU format.
+			LDA	this_seam_pos				;
+			LDX	this_seam_pos+1				;
+			JSR	_calculate_ppufmt_scroll_y	;	Get this_seam_pos in PPU format
+			STA	this_seam_pos				;
+			STX	this_seam_pos+1				;__
+			LDY scroll_direction			;
+			BNE :+							;	If scroll_direction equals 2 (going down),
+				sec							;	new_seam_pos is equal to this_seam_pos
+				sbc #$10					;	But if scroll_direction equals 0 (going up),
+				bcs :+						;	new_seam_pos is equal to this_seam_pos - $10
+					sbc #15					;	(this is just the sub_scroll_y code verbatim,
+					dex						;	the fastest way to get to PPU fmt in this case)
+			:								;__
+			STA	ppufmt_seam_scroll_y		;	Store the next frames' PPU format seam position
+			STX	ppufmt_seam_scroll_y+1		;__
+
+			LDY	this_seam_pos+1		;
 			CPY	#$02				;	If no seam, exit early
 			BCS	@ret0				;__
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -4,6 +4,9 @@
 .import pusha, pushax, callptr4
 .import _scroll_x, _cursedmusic
 
+; LAZY LINEAR INSERT!
+.import _linear_scroll_y
+
 .if VS_SYSTEM
 	.import _draw_arrow
 .endif
@@ -2033,6 +2036,13 @@ doit:
 	lda     #0
 	sta     _scroll_y_subpx
 
+; LAZY LINEAR INSERT!
+lda _scroll_y
+ldx _scroll_y+1
+jsr _calculate_linear_scroll_y
+sta _linear_scroll_y
+stx _linear_scroll_y+1
+
 	; we can't do anything with the high byte of the diff anyway
 
 	rts
@@ -2061,6 +2071,13 @@ doit:
 	; compensate currplayer_rely
 	ldx     _scroll_y
 	ldy     _scroll_y+1
+
+
+; LAZY LINEAR INSERT!
+lda #<$02CF	; the maximum scroll value, but linear
+sta _linear_scroll_y
+lda #>$02CF
+sta _linear_scroll_y+1
 
 	lda     #<$02EF			;
 	sta     sreg			;

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1071,45 +1071,85 @@ ntAddrHiTbl:
 		STA ptr3
 	.endif
 
-	; Seam pos for attributes:
-	; ( <ppufmt_seam_scroll_y & $E0 | >ppufmt_seam_scroll_y & 5) ^ column
-	LDA ppufmt_seam_scroll_y
-	AND #$E0
-	STA SeamValue
-	LDA ppufmt_seam_scroll_y+1
-	AND #$03	; add bit 1 to not use if no seam
-	ORA SeamValue
-	STA SeamValue
+	;	Seam pos for attributes:
+	;	( <seam_scroll_y & $E0 | >seam_scroll_y & 1 | (seam present ? 0 : 2)) ^
+	;__	^ (column & $0E) - $20
+	;	Bits 7-4 define the row where the seam switch occurs
+	;	Bit 0 defines when the seam is activated:
+	;		- if the screen is 0 it's activated on the first pass, if 1 it isn't
+	;		- The value is DECremented
+	;		- if the screen is 0 it isn't activated on the second pass, if 1 it is
+	;	Bits 3-1 are the column where it's iterated
+	;	Bit 1 is also flipped if the seam is absent, so if the bit is set, the column
+	;	no longer corresponds to the column being actively drawn, and so the seam won't
+	;	get activated. (Bit 0 works the same way).
+	;	And then it turns out we're working with something 2 PPU screens / $1E0 pixels ahead
+	;__	So we subtract $20
 
-	LDY	#>collMap2		;__	Get the default value
-	AND #$03			;	Bits 0 and 1 are directly from >ppufmt_seam_scroll_y
-	CMP	#$03			;	For value $FF start at screen 0, otherwise screen 2
-	BNE	:+				;
-		LDY	#>collMap0	;	Get high byte of starting value
-	:					;	(the screen)
-	STY	ptr1+1			;__
+	;	Unfortunately the seam requires every two rows and is attached to ppufmt,
+	;__	so we convert to ppufmt to get which screen we are on
 
-	LDA ptr3			;
-	AND #$0E			;	Get column (w/o highest bit cuz attributes)
-	; ADC #<(collMap0-1) ; the low byte is 0
-	STA ptr1			;__
-	EOR	SeamValue		;	The only overlapping bit is bit 1,
-	STA	SeamValue		;__	if it's invalid the seam won't be drawn
+	LDA seam_scroll_y					;
+	LDX	seam_scroll_y+1					;
+	TAY									;
+	BMI	:+								;	Calculate the ppufmt seam if positive
+		JSR _calculate_ppufmt_scroll_y	;
+	:									;__
 
-	LDX #0
-	STX ColumnBufferIdx
-	JSR attributeCalc
+	TXA			;
+	AND #$01	;	Is it on an odd screen?
+	TAX			;__
 
-	; Increment screen (we always increment)
-	INC ptr1+1
+	TYA						;
+	AND #$E0				;	Calculate the low byte of the seam match
+	ORA	shiftBy4table, X	;__	OR $10 if it's on an odd ppufmt screen
+	SEC						;
+	SBC #$20				;	Compensate for working two screens ahead
+	STA SeamValue			;__
 
-	DEC	SeamValue
+	LDY	#>collMap2			;	Load the default
+	LDX	#(<collMap2>>4)		;__	starting position
 
-	JSR attributeCalc
+	LDA seam_scroll_y+1		;
+	BPL :+					;	If starting at screen 0,
+		LDY #>collMap0		;	load starting position of screen 0
+		LDX #(<collMap0>>4)	;__
+	:
+	AND #$01				;	Enable processing on a certain pass, as mentioned above
+	ORA SeamValue			;__
+	BIT seam_absent			;
+	BPL	:+					;	If the seam is absent,
+		ORA #$02			;	deactivate it
+	:						;__
+	STA SeamValue			;__
+	STY	ptr1+1				;__	Store high byte to free up the Y register
 
-	; Get address hi byte (either left or right side)
-	lda _scroll_x + 1 	; high byte
-	and #%00000001		;
+	LDA ptr3				;
+	AND #$0E				;	Get column (w/o highest bit cuz attributes)
+	TAY						;__
+	ORA shiftBy4table, X	;__	Get the starting pointer low byte
+	STA ptr1				;__ Store the starting pointer
+	TYA						;	Add the column value to the seam
+	EOR	SeamValue			;	Bit 1 overlaps, if it's invalid
+	STA	SeamValue			;__	the seam won't be drawn
+
+	LDX #0					;
+	STX ColumnBufferIdx		;	Calculate the high screen of attributes
+	JSR attributeCalc		;__
+
+	LDA ptr1				;
+	SEC						;
+	SBC #$10				;
+	STA	ptr1				;	Compensate for the ppufmt discrepancy
+	BCS	:+					;
+		DEC ptr1+1			;
+	:						;__
+
+	DEC	SeamValue			;	Calculate the low screen of attributes
+	JSR attributeCalc		;__
+
+	lda _scroll_x + 1 	;
+	and #%00000001		;	Get address hi byte (either left or right side)
 	tay					;	5 cycles, 6 bytes
 	lda	ntAddrHiTbl, Y	;__
 	sta NametableAddrHi
@@ -1223,15 +1263,21 @@ attributeCalc:
 		STA columnBuffer,X
 
 		; Increment pointer
-		LDA	ptr1
-		CMP SeamValue
-		BNE :+
-			DEC ptr1+1
-			DEC ptr1+1
-		:
+		LDX ptr1
+		LDA #$20
+		CPX SeamValue
+		BNE @ptrIncNoSeam
+			DEC SeamValue	;__	Invalidate the seam value
+			DEC ptr1+1		;
+			DEC ptr1+1		;	- $1E0 + $20 = - $200 + $40
+			LDA #$40		;__
+		@ptrIncNoSeam:
 		CLC
-		ADC #$20
+		ADC ptr1
 		STA	ptr1
+		BCC :+
+			INC ptr1+1
+		:
 
 		INC ColumnBufferIdx
 		DEC LoopCount
@@ -1254,6 +1300,7 @@ ntAddrHiTbl:
 	loop_count = tmp3
 
 	new_seam_pos = ptr1
+	ppufmt_this_seam_pos = ptr1
 	this_seam_pos = ptr2
 	collmap_ptr = ptr3
 
@@ -1293,7 +1340,7 @@ ntAddrHiTbl:
 			BCC :+
 				INX
 			:
-			STA	this_seam_pos+0	;	Store new seam position
+			STA	this_seam_pos	;	Store new seam position
 			STX	this_seam_pos+1	;__
 			STA	new_seam_pos	;	Store new seam position
 			STX	new_seam_pos+1	;__
@@ -1315,7 +1362,7 @@ ntAddrHiTbl:
 
 		@up:
 			;__	Carry is set
-			STA	this_seam_pos+0		;	Store old seam position
+			STA	this_seam_pos		;	Store old seam position
 			STX	this_seam_pos+1		;__
 			SBC	#$10
 			BCS :+
@@ -1350,10 +1397,8 @@ ntAddrHiTbl:
 
 			;	Unfortunately, the calculations require
 			;__	the seam location to be in PPU format.
-			LDA	new_seam_pos					;
-			LDX	new_seam_pos+1					;	If the seam is negative, it doesn't matter much
-			BMI	@seam_pos_negative_skip			;__
-				JSR	_calculate_ppufmt_scroll_y	;	Get new_seam_pos in PPU format
+			BMI	@seam_pos_negative_skip			;	Get new_seam_pos in PPU format
+				JSR	_calculate_ppufmt_scroll_y	;	If the seam is negative, it doesn't matter much
 			@seam_pos_negative_skip:			;__
 			STA	ppufmt_seam_scroll_y			;	Store the next frames' PPU format seam position
 			STX	ppufmt_seam_scroll_y+1			;__
@@ -1361,28 +1406,38 @@ ntAddrHiTbl:
 			ROR	seam_absent						;__
 
 			CPY #$00							;
-			BNE :+								;	If scroll_direction equals 2 (going down),
-				clc								;	new_seam_pos is equal to this_seam_pos
-				adc #$10						;	But if scroll_direction equals 0 (going up),
-				bcc :+							;	new_seam_pos is equal to this_seam_pos - $10
-					adc #15						;	(this is just the add_scroll_y code verbatim,
-					inx							;	the fastest way to get to PPU fmt in this case)
-			:									;__
+			BNE @seam_add_fin					;
+				clc								;	If scroll_direction equals 2 (going down),
+				adc #$10						;	new_seam_pos is equal to this_seam_pos
+				bcs :+							;	But if scroll_direction equals 0 (going up),
+				cmp #$F0						;	new_seam_pos is equal to this_seam_pos - $10
+				bcc	@seam_add_fin				;	(this is just the add_scroll_y code verbatim,
+				:	adc #15						;	the fastest way to get to PPU fmt in this case)
+					inx							;
+			@seam_add_fin:						;__
 
-			STA this_seam_pos
-			STX this_seam_pos+1
+			STA ppufmt_this_seam_pos
+			STX ppufmt_this_seam_pos+1
 
 			CPX	#$02				;	If no seam, exit early
 			BCS	@ret0				;__
 
 	start_writing:
 		@get_collmap_ptr:
-			;	X contains the >ppufmt_seam_scroll_y, Carry is clear
+			;__	Y *still* has the scroll direction, Carry is clear
 			LDA this_seam_pos	;
-			AND	#$F0			;	Get low byte
-			STA	collmap_ptr		;__	(none of these affect the carry)
+			LDX	this_seam_pos+1	;
+			AND	#$F0			;
+			CPY #$00
+			BEQ	:+	;__	Add $1E0 if going down
+				;__	Carry is set
+				INX
+				ADC #($E0-1)
+				BCC	:+
+					INX
+			:
+			STA	collmap_ptr		;__
 			TXA					;
-			ADC	scroll_direction;
 			ORA	#>collMap0		;	Get high byte
 			STA	collmap_ptr+1	;__
 
@@ -1395,7 +1450,7 @@ ntAddrHiTbl:
 
 	write_unified:
 		@shift_addr:
-			LDA	this_seam_pos	;__	Get bits: hhll uuuu (u will be ignored)
+			LDA	ppufmt_this_seam_pos	;__	Get bits: hhll uuuu (u will be ignored)
 			ASL					;	Double 8-bit left shift
 			ADC	#$80			;	to shift the mm bits to the high byte
 			ROL					;__	to get ll00 00hh
@@ -1411,10 +1466,10 @@ ntAddrHiTbl:
 			BCS	:+				;	Get X of nametable
 				ORA	#$04		;__
 			:	ORA	#$20|$40	;__	Get valid nametable addr with horizontal seq update
-			LDY	this_seam_pos+1	;
-			BEQ	:+				;	Get Y of nametable
-				ORA	#$08		;__
-			:	STA	VRAM_BUF+0,X;__	Store the high byte of nametable addr
+			LDY	ppufmt_this_seam_pos+1	;
+			BEQ	:+						;	Get Y of nametable
+				ORA	#$08				;__
+			:	STA	VRAM_BUF+0,X		;__	Store the high byte of nametable addr
 		@store_length:
 			LDA	#64				;	Store length
 			STA	VRAM_BUF+2,	X	;__
@@ -1470,7 +1525,7 @@ ntAddrHiTbl:
 		;		 \Combined length of 32(+6)/ \Combined length of 32(+6)/
 
 		@shift_addr:
-			LDA	this_seam_pos	;__	Get bits: hhll uuuu (u will be ignored)
+			LDA	ppufmt_this_seam_pos	;__	Get bits: hhll uuuu (u will be ignored)
 			ASL					;	Double 8-bit left shift
 			ADC	#$80			;	to shift the mm bits to the high byte
 			ROL					;__	to get ll00 00hh
@@ -1492,9 +1547,9 @@ ntAddrHiTbl:
 			BCC	:+				;	Get X of nametable
 				ORA	#$04		;__
 			:	ORA	#$20|$40	;__	Get valid nametable addr with horizontal seq update
-			LDY	this_seam_pos+1	;
-			BEQ	:+				;	Get Y of nametable
-				ORA	#$08		;__
+			LDY	ppufmt_this_seam_pos+1	;
+			BEQ	:+						;	Get Y of nametable
+				ORA	#$08				;__
 			:	PHA				;__	Push high byte of nametable addr for writes B & D
 			STA SepWrABuf,	X	;	Store the high byte
 			STA	SepWrCBuf,	X	;__

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1268,11 +1268,11 @@ ntAddrHiTbl:
 	SepWriEnd = Separate2WritesSize
 
 	start:
-		LDA	_scroll_y				;
+		LDA	_linear_scroll_y		;
 		SEC							;
 		SBC	old_draw_scroll_y		;
 		STA	tmp1					;	XY = scroll_y - old_draw_scroll_y
-		LDA	_scroll_y+1				;
+		LDA	_linear_scroll_y+1		;
 		SBC	old_draw_scroll_y+1		;
 		TAY							;__
 
@@ -1330,8 +1330,8 @@ ntAddrHiTbl:
 		@fin:
 			STX	scroll_direction
 
-			LDA	_scroll_y
-			LDY	_scroll_y+1
+			LDA	_linear_scroll_y
+			LDY	_linear_scroll_y+1
 			STA	old_draw_scroll_y
 			STY	old_draw_scroll_y+1
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1350,37 +1350,38 @@ ntAddrHiTbl:
 
 			;	Unfortunately, the calculations require
 			;__	the seam location to be in PPU format.
-			LDA	this_seam_pos					;
-			LDX	this_seam_pos+1					;	If the seam is negative, it doesn't matter much
+			LDA	new_seam_pos					;
+			LDX	new_seam_pos+1					;	If the seam is negative, it doesn't matter much
 			BMI	@seam_pos_negative_skip			;__
-				JSR	_calculate_ppufmt_scroll_y	;	Get this_seam_pos in PPU format
-			@seam_pos_negative_skip:			;
-			STA	this_seam_pos					;
-			STX	this_seam_pos+1					;__
-			LDY scroll_direction				;
-			BNE :+								;	If scroll_direction equals 2 (going down),
-				sec								;	new_seam_pos is equal to this_seam_pos
-				sbc #$10						;	But if scroll_direction equals 0 (going up),
-				bcs :+							;	new_seam_pos is equal to this_seam_pos - $10
-					sbc #15						;	(this is just the sub_scroll_y code verbatim,
-					dex							;	the fastest way to get to PPU fmt in this case)
-			:									;__
+				JSR	_calculate_ppufmt_scroll_y	;	Get new_seam_pos in PPU format
+			@seam_pos_negative_skip:			;__
 			STA	ppufmt_seam_scroll_y			;	Store the next frames' PPU format seam position
 			STX	ppufmt_seam_scroll_y+1			;__
 			CPX	#$02							;	Only the bit 7 of seam_absent matters
 			ROR	seam_absent						;__
 
-			LDY	this_seam_pos+1		;
-			CPY	#$02				;	If no seam, exit early
+			CPY #$00							;
+			BNE :+								;	If scroll_direction equals 2 (going down),
+				clc								;	new_seam_pos is equal to this_seam_pos
+				adc #$10						;	But if scroll_direction equals 0 (going up),
+				bcc :+							;	new_seam_pos is equal to this_seam_pos - $10
+					adc #15						;	(this is just the add_scroll_y code verbatim,
+					inx							;	the fastest way to get to PPU fmt in this case)
+			:									;__
+
+			STA this_seam_pos
+			STX this_seam_pos+1
+
+			CPX	#$02				;	If no seam, exit early
 			BCS	@ret0				;__
 
 	start_writing:
 		@get_collmap_ptr:
-			;	Y contains the >ppufmt_seam_scroll_y, Carry is clear
+			;	X contains the >ppufmt_seam_scroll_y, Carry is clear
 			LDA this_seam_pos	;
 			AND	#$F0			;	Get low byte
 			STA	collmap_ptr		;__	(none of these affect the carry)
-			TYA					;
+			TXA					;
 			ADC	scroll_direction;
 			ORA	#>collMap0		;	Get high byte
 			STA	collmap_ptr+1	;__

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -669,58 +669,6 @@ single_rle_byte:
 .endproc
 
 
-; [Not used in C]
-.segment _BACKGROUND_RENDER_BANK
-
-.import _scroll_y
-
-.export get_seam_scroll_y
-.proc get_seam_scroll_y
-	; No inputs
-	; Returns seam_scroll_y in AX
-start:
-	BIT	extceil
-	BPL	noSeam
-
-yesSeam:
-	; Seam position:
-	; Y ≥	| Y <	| A		| B		|
-	; 	0	|  $78	|	0	|	1	|
-	;  $78	| $178	|  2/0	|	1	|
-	; $178	| $278	|	2	|  3/1	|
-	; $278	| $2F0	|	2	|	3	|
-
-	; Get seam position
-	LDA	_scroll_y
-	LDX	_scroll_y+1
-	SEC
-	SBC	#$78	;
-	BCS	:+		;	AX = scroll_y - $78
-		SBC #$10-1;	(with valid scroll_y coordinates)
-		DEX		;__
-	:
-	STA	seam_scroll_y
-	STX seam_scroll_y+1
-
-	RTS
-
-noSeam:
-	; The level's ceiling ≤ 27 blocks, no need for a seam
-	LDA	#$78
-	LDX #$02
-	STA	seam_scroll_y
-	STX	seam_scroll_y+1
-	RTS
-
-	; Total seam system:
-	; High byte	| Seam screen	| A		| B		|
-	;	FF		|	There isn't	|	0	| 	1	|
-	;	00		|		00		|  2/0	|	1	|
-	;	01		|		01		|	2	|  3/1	|
-	;	02		|	There isn't	|	2	|	3	|
-	;	No seam can be distinguished by high byte >= 02 or bit 1
-.endproc
-
 ; char draw_screen();
 .segment _BACKGROUND_RENDER_BANK
 

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -2036,8 +2036,8 @@ early_exit:
 ; void cap_scroll_y_at_top();
 .segment _SCROLL_BANK
 
-.importzp _currplayer_y
-.import _scroll_y, _player_y, _scroll_y_subpx
+.importzp _currplayer_rely
+.import _scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_top
 .proc _cap_scroll_y_at_top
@@ -2050,7 +2050,7 @@ check:
 	rts
 
 doit:
-	; compensate currplayer_y and player_y
+	; compensate currplayer_rely and player_rely
 	lda     _scroll_y
 	ldx     _scroll_y+1
 	sta     sreg
@@ -2064,23 +2064,23 @@ doit:
 	eor     #$FF			;__	Make the ADCs into SBCs
 	tay
 
-	lda     _currplayer_y	;
-	sec						;
-	sbc     _scroll_y_subpx	;
-	sta     _currplayer_y	;	Compensate currplayer_y
-	sta		_player_y+1		;	(Apparently guaranteed to be 0)
-	tya						;
-	adc     _currplayer_y+1	;
-	sta     _currplayer_y+1	;
-	sta     _player_y+1		;__
+	lda     _currplayer_rely	;
+	sec							;
+	sbc     _scroll_y_subpx		;
+	sta     _currplayer_rely	;	Compensate currplayer_rely
+	sta		_player_rely+1		;	(Apparently guaranteed to be 0)
+	tya							;
+	adc     _currplayer_rely+1	;
+	sta     _currplayer_rely+1	;
+	sta     _player_rely+1		;__
 
-	lda     _player_y+2		;
-	sec						;
-	sbc     _scroll_y_subpx	;
-	sta     _player_y+2		;	Compensate player_y[1]
-	tya						;
-	adc     _player_y+2+1	;
-	sta     _player_y+2+1	;__
+	lda     _player_rely+2		;
+	sec							;
+	sbc     _scroll_y_subpx		;
+	sta     _player_rely+2		;	Compensate player_rely[1]
+	tya							;
+	adc     _player_rely+2+1	;
+	sta     _player_rely+2+1	;__
 
 	lda     #0
 	sta     _scroll_y_subpx
@@ -2094,8 +2094,8 @@ doit:
 ; void cap_scroll_y_at_bottom();
 .segment _SCROLL_BANK
 
-.importzp _currplayer_y
-.import _scroll_y, _player_y, _scroll_y_subpx
+.importzp _currplayer_rely
+.import _scroll_y, _player_rely, _scroll_y_subpx
 
 .export _cap_scroll_y_at_bottom
 .proc _cap_scroll_y_at_bottom
@@ -2110,7 +2110,7 @@ check:
 	rts
 
 doit:
-	; compensate currplayer_y
+	; compensate currplayer_rely
 	ldx     _scroll_y
 	ldy     _scroll_y+1
 
@@ -2126,23 +2126,23 @@ doit:
 	jsr     _calculate_linear_scroll_y	;__
 	tay
 
-	lda     _currplayer_y	;
-	clc						;
-	adc     _scroll_y_subpx	;
-	sta     _currplayer_y	;	Compensate currplayer_y
-	sta		_player_y+1		;	(Apparently guaranteed to be 0)
-	tya						;
-	adc     _currplayer_y+1	;
-	sta     _currplayer_y+1	;
-	sta     _player_y+1		;__
+	lda     _currplayer_rely	;
+	clc							;
+	adc     _scroll_y_subpx		;
+	sta     _currplayer_rely	;	Compensate currplayer_rely
+	sta		_player_rely+1		;	(Apparently guaranteed to be 0)
+	tya							;
+	adc     _currplayer_rely+1	;
+	sta     _currplayer_rely+1	;
+	sta     _player_rely+1		;__
 
-	lda     _player_y+2		;
-	clc						;
-	adc     _scroll_y_subpx	;
-	sta     _player_y+2		;	Compensate player_y[1]
-	tya						;
-	adc     _player_y+2+1	;
-	sta     _player_y+2+1	;__
+	lda     _player_rely+2		;
+	clc							;
+	adc     _scroll_y_subpx		;
+	sta     _player_rely+2		;	Compensate player_rely[1]
+	tya							;
+	adc     _player_rely+2+1	;
+	sta     _player_rely+2+1	;__
 
 	lda     #0
 	sta     _scroll_y_subpx
@@ -2252,7 +2252,7 @@ end:
 
 .segment _PLAYER_RENDER_BANK
 
-.import _player_x, _player_y, _player_gravity, _player_vel_x, _player_vel_y, _player_mini
+.import _player_relx, _player_rely, _player_gravity, _player_vel_x, _player_vel_y, _player_mini
 .import _ballframe, _robotframe, _robotjumpframe, _spiderframe, _orbed
 .import _retro_mode, _icon, _gameState, _titleicon, _skipProcessingCubeRotationLogic
 .import _CUBE_GRAVITY_lo, _chargepower
@@ -2344,8 +2344,8 @@ drawplayer_center_offsets:
 		LDA #$80
 	: STA xargs+0
 
-	LDX _player_y+1		;
-	DEX					;	The Y of oam_meta_spr is high_byte(player_y[0])-1
+	LDX _player_rely+1	;
+	DEX					;	The Y of oam_meta_spr is high_byte(player_rely[0])-1
 	STX sreg+1			;__
 
 	; Set up base pointer for jump tables
@@ -2368,7 +2368,7 @@ drawplayer_center_offsets:
 	PLA				;	Get pure gamemode number
 	TAX				;__
 
-	LDY _player_x+1     ;__ temp_x = high_byte(player_x[0]);
+	LDY _player_relx+1     ;__ temp_x = high_byte(player_relx[0]);
 	; The condition if is temp_x == 0 or is > 0xfc,
 	; this can be expressed as (temp_x - 1) > 0xfb
 	DEY					;
@@ -2924,7 +2924,7 @@ drawplayer_center_offsets:
 		LDA (ptr1), Y		;	Load high byte
 		TAX					;__
 		PLA
-		JMP __oam_meta_spr_flipped ;__	oam_meta_spr(temp_x, high_byte(player_y[0])-1, [whatever the fuck we set here]);
+		JMP __oam_meta_spr_flipped ;__	oam_meta_spr(temp_x, high_byte(player_rely[0])-1, [whatever the fuck we set here]);
 
     sprite_table_table_lo:
         .byte <_CUBE, <_SHIP, <_BALL, <_UFO, <_ROBOT, <_SPIDER, <_WAVE, <_SWING, <_CUBE, <_POGO, <_SNAKE, <_CUBE
@@ -2974,8 +2974,8 @@ drawplayer_common := _drawplayerone::common
 		LDA #$80
 	: STA xargs+0	; flip
 
-	LDX _player_y+3		;
-	DEX					;	The Y of oam_meta_spr is high_byte(player_y[1])-1
+	LDX _player_rely+3	;
+	DEX					;	The Y of oam_meta_spr is high_byte(player_rely[1])-1
 	STX sreg+1			;__
 
 	; Set up base pointer for jump tables
@@ -2998,7 +2998,7 @@ drawplayer_common := _drawplayerone::common
 	PLA				;	Get pure gamemode number
 	TAX				;__
 
-	LDY _player_x+3     ;__ temp_x = high_byte(player_x[1]);
+	LDY _player_relx+3     ;__ temp_x = high_byte(player_relx[1]);
 	; The condition if is temp_x == 0 or is > 0xfc,
 	; this can be expressed as (temp_x - 1) > 0xfb
 	DEY					;

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -73,8 +73,9 @@ sprite_data = _sprite_data
 	min_scroll_y:		.res 2
 
 	; variables related to both the above and below
-	old_draw_scroll_y:	.res 2
-	seam_scroll_y:		.res 2
+	old_draw_scroll_y:		.res 2
+	seam_scroll_y:			.res 2
+	ppufmt_seam_scroll_y:	.res 2
 	
 	; variables related to draw_screen
 	rld_column:			.res 1
@@ -91,6 +92,7 @@ sprite_data = _sprite_data
 .export _extceil := extceil
 .export _min_scroll_y := min_scroll_y
 .export	_seam_scroll_y := seam_scroll_y
+.export	_ppufmt_seam_scroll_y := ppufmt_seam_scroll_y
 .export _old_draw_scroll_y := old_draw_scroll_y
 
 .export _drawing_frame := drawing_frame
@@ -771,8 +773,8 @@ frame1:
 
 calc_seam_pos:
 
-	LDA seam_scroll_y
-	LDX seam_scroll_y+1
+	LDA ppufmt_seam_scroll_y
+	LDX ppufmt_seam_scroll_y+1
 
 	LDY	#15+15	;__	Load the starting nametable into Y
 
@@ -1074,17 +1076,17 @@ ntAddrHiTbl:
 	.endif
 
 	; Seam pos for attributes:
-	; ( <seam_scroll_y & $E0 | >seam_scroll_y & 5) ^ column
-	LDA seam_scroll_y
+	; ( <ppufmt_seam_scroll_y & $E0 | >ppufmt_seam_scroll_y & 5) ^ column
+	LDA ppufmt_seam_scroll_y
 	AND #$E0
 	STA SeamValue
-	LDA seam_scroll_y+1
+	LDA ppufmt_seam_scroll_y+1
 	AND #$03	; add bit 1 to not use if no seam
 	ORA SeamValue
 	STA SeamValue
 
 	LDY	#>collMap2		;__	Get the default value
-	AND #$03			;	Bits 0 and 1 are directly from >seam_scroll_y
+	AND #$03			;	Bits 0 and 1 are directly from >ppufmt_seam_scroll_y
 	CMP	#$03			;	For value $FF start at screen 0, otherwise screen 2
 	BNE	:+				;
 		LDY	#>collMap0	;	Get high byte of starting value
@@ -1286,8 +1288,8 @@ ntAddrHiTbl:
 		@start:
 			LDA	#$10
 			STA	sreg+0
-			LDA	seam_scroll_y
-			LDX	seam_scroll_y+1
+			LDA	ppufmt_seam_scroll_y
+			LDX	ppufmt_seam_scroll_y+1
 			CPY	#$00	;	Puts carry into X
 			BMI	@up		;__
 		
@@ -1337,8 +1339,8 @@ ntAddrHiTbl:
 
 			LDA	new_seam_pos
 			LDY	new_seam_pos+1
-			STA	seam_scroll_y
-			STY	seam_scroll_y+1
+			STA	ppufmt_seam_scroll_y
+			STY	ppufmt_seam_scroll_y+1
 
 			LDY	this_seam_pos+1
 			CPY	#$02				;	If no seam, exit early
@@ -1346,7 +1348,7 @@ ntAddrHiTbl:
 
 	start_writing:
 		@get_collmap_ptr:
-			;	Y contains the >seam_scroll_y, Carry is clear
+			;	Y contains the >ppufmt_seam_scroll_y, Carry is clear
 			LDA this_seam_pos	;
 			AND	#$F0			;	Get low byte
 			STA	collmap_ptr		;__	(none of these affect the carry)

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -3506,13 +3506,13 @@ drawplayer_common := _drawplayerone::common
 ; char bg_collision_sub();
 .segment "CODE_2"
 
-.importzp _temp_x, _temp_y, _temp_room, _collision
+.importzp _temp_x, _temp_y, _collision
 
 .export _bg_collision_sub
 .proc _bg_collision_sub
     ; Returns collision block indexed by
 	; temp_x for X
-	; temp_room and y for Y
+	; temp_y for Y
     LDA _temp_y     ;
     CMP #$F0        ;   if(temp_y >= 0xf0) return 0;
     BCS Return0		;__
@@ -3526,8 +3526,8 @@ drawplayer_common := _drawplayerone::common
 	ORA tmp1		;	coordinates = (temp_x >> 4) + ((temp_y) & 0xf0);
 	TAY				;__
 
-	LDA _temp_room	;	tmp3 = temp_room&3;
-	AND #$03		;__
+	LDA _temp_y+1
+	AND #$03
 	ORA #>collMap0
 	STA ptr1+1
 	LDA #$00

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1118,7 +1118,11 @@ ntAddrHiTbl:
 	SEC						;
 	SBC #$20				;__	Compensate for working two screens ahead
 	CPX #1					;	(Add X, which is 1 or 0, to the value)
-	ADC #0					;	Enable processing on a certain pass, as mentioned above
+	ADC #0					;__	Enable processing on a certain pass, as mentioned above
+	BIT seam_absent			;
+	BPL	:+					;	If the seam is absent,
+		ORA #$02			;	deactivate it
+	:						;
 	STA	SeamValue			;__
 
 	LDY	#>collMap2			;	Load the default
@@ -1129,12 +1133,6 @@ ntAddrHiTbl:
 		LDY #>collMap0		;	load starting position of screen 0
 		LDX #(<collMap0>>4)	;__
 	:
-	LDA SeamValue			;
-	BIT seam_absent			;
-	BPL	:+					;	If the seam is absent,
-		ORA #$02			;	deactivate it
-	:						;__
-	STA SeamValue			;__
 	STY	ptr1+1				;__	Store high byte to free up the Y register
 
 	LDA ptr3				;

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1116,8 +1116,10 @@ ntAddrHiTbl:
 	AND #$E0				;	Calculate the low byte of the seam match
 	ORA	shiftBy4table, X	;__	OR $10 if it's on an odd ppufmt screen
 	SEC						;
-	SBC #$20				;	Compensate for working two screens ahead
-	STA SeamValue			;__
+	SBC #$20				;__	Compensate for working two screens ahead
+	CPX #1					;	(Add X, which is 1 or 0, to the value)
+	ADC #0					;	Enable processing on a certain pass, as mentioned above
+	STA	SeamValue			;__
 
 	LDY	#>collMap2			;	Load the default
 	LDX	#(<collMap2>>4)		;__	starting position
@@ -1127,8 +1129,7 @@ ntAddrHiTbl:
 		LDY #>collMap0		;	load starting position of screen 0
 		LDX #(<collMap0>>4)	;__
 	:
-	AND #$01				;	Enable processing on a certain pass, as mentioned above
-	ORA SeamValue			;__
+	LDA SeamValue			;
 	BIT seam_absent			;
 	BPL	:+					;	If the seam is absent,
 		ORA #$02			;	deactivate it

--- a/LIB/asm/nesdash.s
+++ b/LIB/asm/nesdash.s
@@ -1106,20 +1106,13 @@ ntAddrHiTbl:
 	;__	So we subtract $20
 
 	;	Unfortunately the seam requires every two rows and is attached to ppufmt,
-	;__	so we convert to ppufmt to get which screen we are on
+	;__	so we use the ppufmt screen value
 
-	LDA seam_position					;
-	LDX	seam_position+1					;
-	TAY									;
-	BMI	:+								;	Calculate the ppufmt seam if positive
-		JSR _calculate_ppufmt_scroll_y	;
-	:									;__
+	LDA	seam_position_screen	;
+	AND #$01					;	Is it on an odd screen?
+	TAX							;__
 
-	TXA			;
-	AND #$01	;	Is it on an odd screen?
-	TAX			;__
-
-	TYA						;
+	LDA seam_position		;
 	AND #$E0				;	Calculate the low byte of the seam match
 	ORA	shiftBy4table, X	;__	OR $10 if it's on an odd ppufmt screen
 	SEC						;

--- a/LIB/asm/nesdoug.s
+++ b/LIB/asm/nesdoug.s
@@ -113,7 +113,7 @@ _get_frame_count:
 	
 PTR2 = TEMP+2 ;and TEMP+3
 
-.import _Generic, _Generic2
+.importzp _Generic, _Generic2
 ;uint8_t __fastcall__ check_collision(void * object1, void * object2);
 ; __check_collision:
 _check_collision:

--- a/LIB/headers/nesdash.h
+++ b/LIB/headers/nesdash.h
@@ -10,6 +10,10 @@ extern uint8_t xargs[4];
 #define storeBytesToSreg(a, b) (__AX__ = (byte(b)<<8)|byte(a), __EAX__<<=16)
 #define storeByteToSreg(byte) (__A__ = byte, __asm__("sta sreg+0"))
 
+extern uint8_t shiftBy4table[16];
+#define shlNibble4(nibble) (idx8_load(shiftBy4table, nibble))
+#define shlNibble12(nibble) (idx8_load(shiftBy4table, nibble), __AX__ <<= 8)
+
 /**
  * @brief set metasprite in OAM buffer (horizontally and/or vertically flipped, depending on flip parameter)
  * @param flip
@@ -91,7 +95,7 @@ void __fastcall__ music_update();
  *
  * @retval The number in linear pixels.
  */
-uint16_t calculate_linear_scroll_y(uint16_t nonlinearScroll);
+#define calculate_linear_scroll_y(nonlinearScroll) (__AX__ = nonlinearScroll, __asm__("sec \n sbc %v, x \n bcs %s \n dex \n %s:", shiftBy4table, __LINE__, __LINE__), __AX__)
 
 /**
  * @brief Converts a number from linear pixels to NES PPU Y scroll pixels.
@@ -310,10 +314,6 @@ extern uint8_t PAL_BUF[32];
 #define jumpInTableWithOffset(tbl, val, off) ( \
 	__A__ = val << 1, \
 	__asm__("tay \n lda %v-%w, y \n ldx %v-%w+1, y \n jsr callax ", tbl, (off * 2), tbl, (off * 2)))
-
-extern uint8_t shiftBy4table[16];
-#define shlNibble4(nibble) (idx8_load(shiftBy4table, nibble))
-#define shlNibble12(nibble) (idx8_load(shiftBy4table, nibble), __AX__ <<= 8)
 
 // Result in __AX__
 #define signExtend8to16(value) {__AX__ = 0; __A__ = value; do_if_negative({__asm__("dex");});}

--- a/LIB/headers/nesdash.h
+++ b/LIB/headers/nesdash.h
@@ -85,13 +85,22 @@ void __fastcall__ _sfx_play(uint16_t args);
 void __fastcall__ music_update();
 
 /**
- * @brief Converts a number from scroll_y pixels to linear pixels.
+ * @brief Converts a number from NES PPU Y scroll pixels to linear pixels.
  *
- * @param nonlinearScroll The number in scroll_y pixels to convert.
+ * @param nonlinearScroll The number in NES PPU Y scroll pixels to convert.
  *
  * @retval The number in linear pixels.
  */
 uint16_t calculate_linear_scroll_y(uint16_t nonlinearScroll);
+
+/**
+ * @brief Converts a number from linear pixels to NES PPU Y scroll pixels.
+ *
+ * @param linearScroll The number in linear pixels to convert.
+ *
+ * @return The number in NES PPU Y scroll pixels.
+ */
+uint16_t calculate_ppufmt_scroll_y(uint16_t linearScroll);
 
 /**
  * @brief Caps the Y scroll at min_scroll_y

--- a/SAUCE/defines/dialogbox.h
+++ b/SAUCE/defines/dialogbox.h
@@ -38,13 +38,13 @@ void draw_dialog_box(const char * data);
 
 const char dialogBox_saveFileSafetyHeader[] = "$$SAVE$$FILE$$SAFETY$$\v\2";
 const char dialogBox_pleasePressB[] = "\a please hold  (RESET)\v\2  while powering off\v\2\t\3real nes/famicom \v\2  hardware  to avoid\v\2 save file corruption\v\2\b  [\t\20]  \n  $PRESS$ANY$BUTTON$\n  $$$TO$$CONTINUE$$$\n\b  {\t\20}  ";
-const char dialogBox_itIsNowSafe[] = "\a\n  it is now safe to\v\2 turn off your system\v\6\b  [\t\20]  \n  $$$$PRESS$B$TO$$$$\n  $$$$GO$BACK$TO$$$$\n  $THE$TITLE$SCREEN$\n\b  {\t\20}  ";
+// const char dialogBox_itIsNowSafe[] = "\a\n  it is now safe to\v\2 turn off your system\v\6\b  [\t\20]  \n  $$$$PRESS$B$TO$$$$\n  $$$$GO$BACK$TO$$$$\n  $THE$TITLE$SCREEN$\n\b  {\t\20}  ";
 
-const char dialogBox_wrongSaveFileVersion[] = " for a\a version";
-const char dialogBox_nolder[] = "n older";
-const char dialogBox_newer[] = " newer ";
-const char dialogBox_saveFileMissingCorrupt[] = "  missing or corrupt";
-const char dialogBox_saveIssues[] = "$$INVALID$$SAVE$FILE$$\v\5  your save  file is\v\2\a\v\6 (A;$CREATE$NEW$SAVE)\v\2 (B;$LOAD$ANYWAY$$$$)";
+// const char dialogBox_wrongSaveFileVersion[] = " for a\a version";
+// const char dialogBox_nolder[] = "n older";
+// const char dialogBox_newer[] = " newer ";
+// const char dialogBox_saveFileMissingCorrupt[] = "  missing or corrupt";
+// const char dialogBox_saveIssues[] = "$$INVALID$$SAVE$FILE$$\v\5  your save  file is\v\2\a\v\6 (A;$CREATE$NEW$SAVE)\v\2 (B;$LOAD$ANYWAY$$$$)";
 
 #include "defines/charmap/no_remap_charmap.h"
 #pragma rodata-name (pop)

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -431,6 +431,7 @@ uint8_t parallax_scroll_x;
 uint8_t invincible_counter;
 uint32_t scroll_x; // gotta love massive levels amirite fellas
 uint16_t scroll_y;
+uint16_t linear_scroll_y;
 uint8_t scroll_y_subpx;
 uint16_t old_trail_scroll_y;
 uint16_t target_scroll_y;

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -149,8 +149,7 @@ uint8_t x; // room loader code
 uint8_t y;
 uint8_t index;
 uint8_t temp_x;
-uint8_t temp_y;
-uint8_t temp_room;
+uint16_t temp_y;
 uint8_t dual;
 int8_t slope_frames[2];
 

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -179,6 +179,8 @@ extern uint8_t fullRegion;
 struct Base Generic;
 struct Base Generic2;
 
+uint16_t transitional_linear_absolute_currplayer_y;
+
 // SRAM
 #pragma bss-name("SRAM")
 uint8_t SRAM_VALIDATE[4];

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -294,7 +294,6 @@ uint8_t practice_outline_color[MAX_PRACTICE_POINTS];
 uint8_t practice_g_color_type[MAX_PRACTICE_POINTS];
 uint8_t practice_bg_color_type[MAX_PRACTICE_POINTS];
 //uint8_t practice_trail_sprites_visible[9];
-//uint8_t practice_player_old_posy[9];
 uint8_t practice_orbactive[MAX_PRACTICE_POINTS];
 uint8_t practice_nullscapes_active[MAX_PRACTICE_POINTS];
 uint8_t practice_nullscapes_orb_type[MAX_PRACTICE_POINTS];
@@ -499,7 +498,7 @@ uint8_t iconbank;
 uint8_t dblocked[2];
 
 
-uint8_t player_old_posy[9];
+uint8_t player_old_rely[9];
 uint8_t discorefreshrate;
 uint8_t discoframe;
 uint8_t no_parallax;

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -434,7 +434,7 @@ uint16_t scroll_y;
 uint16_t linear_scroll_y;
 uint8_t scroll_y_subpx;
 uint16_t old_trail_scroll_y;	// Moved to linear!
-uint16_t target_scroll_y;
+uint16_t target_scroll_y;	// Moved to linear!
 //uint16_t reload_target_scroll_y;
 uint8_t song;
 uint8_t songplaying;
@@ -452,7 +452,7 @@ uint16_t coin2_speed;
 uint16_t coin3_speed;
 
 uint16_t spawn_y_pos;
-uint16_t spawn_scroll_y_pos;
+uint16_t spawn_scroll_y_pos;	// Moved to linear!
 uint8_t max_fallspeed_7;
 
 #if __VS_SYSTEM

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -288,7 +288,7 @@ lohi_arr32_decl(practice_scroll_x, MAX_PRACTICE_POINTS);
 lohi_arr16_decl(practice_scroll_y, MAX_PRACTICE_POINTS);
 uint8_t practice_scroll_y_subpx[MAX_PRACTICE_POINTS];
 lohi_arr16_decl(practice_min_scroll_y, MAX_PRACTICE_POINTS);
-lohi_arr16_decl(practice_seam_scroll_y, MAX_PRACTICE_POINTS);
+lohi_arr16_decl(practice_seam_position, MAX_PRACTICE_POINTS);
 lohi_arr16_decl(practice_old_draw_scroll_y, MAX_PRACTICE_POINTS);
 lohi_arr16_decl(practice_target_scroll_y, MAX_PRACTICE_POINTS);
 
@@ -566,8 +566,9 @@ uint8_t player_invis;
 extern uint8_t famistudio_song_speed;
 
 extern uint16_t min_scroll_y;
-extern uint16_t seam_scroll_y;
-extern uint16_t ppufmt_seam_scroll_y;
+extern uint16_t seam_position;
+extern uint8_t seam_position_screen;
+extern uint8_t seam_absent;
 
 extern volatile uint8_t hexToDecOutputBuffer[5];
 

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -111,8 +111,8 @@ extern volatile unsigned char VRAM_UPDATE;
 #pragma zpsym ("VRAM_UPDATE")
 
 uint8_t currplayer_mini;
-uint16_t currplayer_x;
-uint16_t currplayer_y;
+uint16_t currplayer_relx;
+uint16_t currplayer_rely;
 int16_t currplayer_vel_x;
 int16_t currplayer_vel_y;
 uint8_t currplayer_gravity;
@@ -323,8 +323,8 @@ extern uint8_t trueFullRegion;
 
 uint8_t last_gameState;
 
-uint16_t player_x[2];
-uint16_t player_y[2];
+uint16_t player_relx[2];
+uint16_t player_rely[2];
 int16_t player_vel_x[2];
 int16_t player_vel_y[2];
 uint8_t player_gravity[2];

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -180,6 +180,7 @@ struct Base Generic;
 struct Base Generic2;
 
 uint16_t transitional_linear_absolute_currplayer_y;
+uint8_t transitional_sixteen_minus_generic_height_halved;
 
 // SRAM
 #pragma bss-name("SRAM")

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -433,7 +433,7 @@ uint32_t scroll_x; // gotta love massive levels amirite fellas
 uint16_t scroll_y;
 uint16_t linear_scroll_y;
 uint8_t scroll_y_subpx;
-uint16_t old_trail_scroll_y;
+uint16_t old_trail_scroll_y;	// Moved to linear!
 uint16_t target_scroll_y;
 //uint16_t reload_target_scroll_y;
 uint8_t song;

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -242,7 +242,6 @@ uint8_t gameboy_mode;
 uint8_t invisblocks;
 uint8_t cam_seesaw;
 uint8_t forced_credits;
-extern uint8_t extceil;
 uint8_t drawBarFlag;
 uint8_t exitPortalTimer;
 uint8_t menu_music;
@@ -516,6 +515,7 @@ uint8_t discorefreshrate;
 uint8_t discoframe;
 uint8_t no_parallax;
 uint8_t force_platformer;
+extern uint8_t extceil;
 uint8_t outline_color;
 uint8_t forced_trails;
 uint8_t skipProcessingCubeRotationLogic;
@@ -568,6 +568,7 @@ extern uint8_t famistudio_song_speed;
 
 extern uint16_t min_scroll_y;	// Moved to linear!
 extern uint16_t seam_scroll_y;
+extern uint16_t ppufmt_seam_scroll_y;
 
 extern volatile uint8_t hexToDecOutputBuffer[5];
 

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -52,6 +52,13 @@
 #define REGION_PAL		1
 #define REGION_DENDY	2
 
+struct Base {
+	uint8_t x;
+	uint8_t y;
+	uint8_t width;
+	uint8_t height;
+};
+
 // Zeropage variables
 #pragma bss-name("ZEROPAGE")
 
@@ -168,6 +175,9 @@ extern uint8_t fullRegion;
 #pragma zpsym ("framerate")
 #pragma zpsym ("cpuRegion")
 #pragma zpsym ("fullRegion")
+
+struct Base Generic;
+struct Base Generic2;
 
 // SRAM
 #pragma bss-name("SRAM")
@@ -575,13 +585,3 @@ extern volatile uint8_t hexToDecOutputBuffer[5];
 //};
 
 //struct player2 player2 = {0x0000,0xb000};
-
-struct Base {
-	uint8_t x;
-	uint8_t y;
-	uint8_t width;
-	uint8_t height;
-};
-
-struct Base Generic;
-struct Base Generic2;

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -554,7 +554,7 @@ uint8_t player_invis;
 
 extern uint8_t famistudio_song_speed;
 
-extern uint16_t min_scroll_y;
+extern uint16_t min_scroll_y;	// Moved to linear!
 extern uint16_t seam_scroll_y;
 
 extern volatile uint8_t hexToDecOutputBuffer[5];

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -441,7 +441,6 @@ extern uint8_t parallax_scroll_column_start;
 uint8_t parallax_scroll_x;
 uint8_t invincible_counter;
 uint32_t scroll_x; // gotta love massive levels amirite fellas
-uint16_t scroll_y;
 uint16_t linear_scroll_y;
 uint8_t scroll_y_subpx;
 uint16_t old_trail_scroll_y;	// Moved to linear!

--- a/SAUCE/famidash.h
+++ b/SAUCE/famidash.h
@@ -441,10 +441,10 @@ extern uint8_t parallax_scroll_column_start;
 uint8_t parallax_scroll_x;
 uint8_t invincible_counter;
 uint32_t scroll_x; // gotta love massive levels amirite fellas
-uint16_t linear_scroll_y;
+uint16_t scroll_y;
 uint8_t scroll_y_subpx;
-uint16_t old_trail_scroll_y;	// Moved to linear!
-uint16_t target_scroll_y;	// Moved to linear!
+uint16_t old_trail_scroll_y;
+uint16_t target_scroll_y;
 //uint16_t reload_target_scroll_y;
 uint8_t song;
 uint8_t songplaying;
@@ -462,7 +462,7 @@ uint16_t coin2_speed;
 uint16_t coin3_speed;
 
 uint16_t spawn_y_pos;
-uint16_t spawn_scroll_y_pos;	// Moved to linear!
+uint16_t spawn_scroll_y_pos;
 uint8_t max_fallspeed_7;
 
 #if __VS_SYSTEM
@@ -565,7 +565,7 @@ uint8_t player_invis;
 
 extern uint8_t famistudio_song_speed;
 
-extern uint16_t min_scroll_y;	// Moved to linear!
+extern uint16_t min_scroll_y;
 extern uint16_t seam_scroll_y;
 extern uint16_t ppufmt_seam_scroll_y;
 

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -422,7 +422,7 @@ char bg_coll_slope();
 
 */
 char bg_side_coll_common() {
-	tmp1 = Generic.y + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (Generic.height >> 1);
+	tmp1 = (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0)) + (Generic.height >> 1);
 
 	if (currplayer_mini && (gamemode == GAMEMODE_CUBE || gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA)) {
 		tmp1 += (currplayer_gravity ? 3 : -2);
@@ -432,7 +432,7 @@ char bg_side_coll_common() {
 		return 0;
 	}
 
-	temp_y = add_scroll_y(tmp1, scroll_y);
+	temp_y = calculate_ppufmt_scroll_y(transitional_linear_absolute_currplayer_y + tmp1);
 
 	bg_collision_sub();
 	if (collision) {

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -35,7 +35,6 @@ CODE_BANK_PUSH("XCD_BANK_01")
 	Implemented in asm
 */
 char bg_collision_sub();
-void tmp20f();
 
 
 /*
@@ -220,9 +219,8 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// TOP	
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	temp_y = add_scroll_y(
-		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2,
-		scroll_y
+	temp_y = calculate_ppufmt_scroll_y(
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2)
 	);
 
 	bg_collision_sub();
@@ -242,9 +240,8 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// BOTTOM
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	temp_y = add_scroll_y(
-		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2),
-		scroll_y
+	temp_y = calculate_ppufmt_scroll_y(
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2))
 	);
 
 	bg_collision_sub();

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -993,9 +993,8 @@ char bg_coll_D() {
 
 char bg_coll_U_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	temp_y = add_scroll_y(
-		Generic.y + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-		scroll_y
+	temp_y = calculate_ppufmt_scroll_y(
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0))
 	);
 
 	tmp8 = (temp_y) & 0x0f;
@@ -1011,9 +1010,8 @@ char bg_coll_U_spider() {
 
 char bg_coll_D_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	temp_y = add_scroll_y(
-		Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-		scroll_y
+	temp_y = calculate_ppufmt_scroll_y(
+		transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0))
 	);
 	
 	tmp8 = (temp_y) & 0x0f;

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -884,13 +884,13 @@ char bg_coll_return_slope_U () {
 
 
 char bg_coll_U() {
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 	
 	// Slopes
 
 	if (high_byte(currplayer_relx) >= 0x10) {
-		temp_y = add_scroll_y(
-			Generic.y + transitional_sixteen_minus_generic_height_halved + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
-			scroll_y
+		temp_y = calculate_ppufmt_scroll_y(
+			transitional_linear_absolute_currplayer_y + (uint8_t)(transitional_sixteen_minus_generic_height_halved + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0))
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
 
@@ -912,9 +912,8 @@ char bg_coll_U() {
 	if (high_byte(currplayer_vel_y) & 0x80) {
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 		
-		temp_y = add_scroll_y(
-			Generic.y + ((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)),
-			scroll_y
+		temp_y = calculate_ppufmt_scroll_y(
+			transitional_linear_absolute_currplayer_y + (uint8_t)(((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)))
 		);
 		
 		tmp8 = (temp_y) & 0x0f;
@@ -940,12 +939,12 @@ char bg_coll_U() {
 	tmp1, tmp2, tmp4, tmp7, tmp8
 */
 char bg_coll_D() {
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 
 	// Slopes
 	if (high_byte(currplayer_relx) >= 0x10) {
-		temp_y = add_scroll_y(
-			Generic.y + Generic.height - 2 + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
-			scroll_y
+		temp_y = calculate_ppufmt_scroll_y(
+			transitional_linear_absolute_currplayer_y - 2 + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
 
@@ -967,9 +966,8 @@ char bg_coll_D() {
 		// check 2 points on the right side
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 
-		temp_y = add_scroll_y(
-			Generic.y + Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
-			scroll_y
+		temp_y = calculate_ppufmt_scroll_y(
+			transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 		);
 
 		tmp8 = (temp_y) & 0x0f;
@@ -1039,9 +1037,8 @@ void bg_coll_death() {
 
 	temp_x = Generic.x + low_word(scroll_x) + (Generic.width >> 1)-1; // automatically only the low byte
 
-	temp_y = add_scroll_y(
-		Generic.y + (Generic.height >> 1) + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
-		scroll_y
+	temp_y = calculate_ppufmt_scroll_y(
+		transitional_linear_absolute_currplayer_y + (uint8_t)((Generic.height >> 1) + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 
 	bg_collision_sub();

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -884,7 +884,7 @@ char bg_coll_return_slope_U () {
 
 
 char bg_coll_U() {
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 	
 	// Slopes
 
@@ -939,7 +939,7 @@ char bg_coll_U() {
 	tmp1, tmp2, tmp4, tmp7, tmp8
 */
 char bg_coll_D() {
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 
 	// Slopes
 	if (high_byte(currplayer_relx) >= 0x10) {

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -432,7 +432,7 @@ char bg_side_coll_common() {
 		return 0;
 	}
 
-	storeWordSeparately(add_scroll_y(tmp1, scroll_y), temp_y, temp_room);
+	temp_y = add_scroll_y(tmp1, scroll_y);
 
 	bg_collision_sub();
 	if (collision) {
@@ -888,11 +888,10 @@ char bg_coll_U() {
 	// Slopes
 
 	if (high_byte(currplayer_relx) >= 0x10) {
-		storeWordSeparately(
-			add_scroll_y(
-				Generic.y + (byte(0x10 - Generic.height) >> 1) + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
-				scroll_y
-			), temp_y, temp_room);
+		temp_y = add_scroll_y(
+			Generic.y + (byte(0x10 - Generic.height) >> 1) + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
+			scroll_y
+		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
 
 		tmp2 = 0;
@@ -913,11 +912,10 @@ char bg_coll_U() {
 	if (high_byte(currplayer_vel_y) & 0x80) {
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 		
-		storeWordSeparately(
-			add_scroll_y(
-				Generic.y + ((currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)),
-				scroll_y
-			), temp_y, temp_room);
+		temp_y = add_scroll_y(
+			Generic.y + ((currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)),
+			scroll_y
+		);
 		
 		tmp8 = (temp_y) & 0x0f;
 
@@ -945,10 +943,10 @@ char bg_coll_D() {
 
 	// Slopes
 	if (high_byte(currplayer_relx) >= 0x10) {
-		storeWordSeparately(
-			add_scroll_y(
-				Generic.y + Generic.height - 2 + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0), scroll_y
-			), temp_y, temp_room);
+		temp_y = add_scroll_y(
+			Generic.y + Generic.height - 2 + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+			scroll_y
+		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
 
 		tmp2 = 0;
@@ -969,11 +967,10 @@ char bg_coll_D() {
 		// check 2 points on the right side
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 
-		storeWordSeparately(
-			add_scroll_y(
-				Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-				scroll_y
-			), temp_y, temp_room);
+		temp_y = add_scroll_y(
+			Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+			scroll_y
+		);
 
 		tmp8 = (temp_y) & 0x0f;
 
@@ -996,11 +993,10 @@ char bg_coll_D() {
 
 char bg_coll_U_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	storeWordSeparately(
-		add_scroll_y(
-			Generic.y + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-			scroll_y
-		), temp_y, temp_room);
+	temp_y = add_scroll_y(
+		Generic.y + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+		scroll_y
+	);
 
 	tmp8 = (temp_y) & 0x0f;
 
@@ -1015,11 +1011,10 @@ char bg_coll_U_spider() {
 
 char bg_coll_D_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	storeWordSeparately(
-		add_scroll_y(
-			Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-			scroll_y
-		), temp_y, temp_room);
+	temp_y = add_scroll_y(
+		Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+		scroll_y
+	);
 	
 	tmp8 = (temp_y) & 0x0f;
 
@@ -1046,11 +1041,10 @@ void bg_coll_death() {
 
 	temp_x = Generic.x + low_word(scroll_x) + (Generic.width >> 1)-1; // automatically only the low byte
 
-	storeWordSeparately(
-		add_scroll_y(
-			Generic.y + (Generic.height >> 1) + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
-			scroll_y
-		), temp_y, temp_room);
+	temp_y = add_scroll_y(
+		Generic.y + (Generic.height >> 1) + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+		scroll_y
+	);
 
 	bg_collision_sub();
 	
@@ -1080,17 +1074,16 @@ void bg_coll_death() {
 }
 
 void commonly_used_store() {
-		storeWordSeparately(
-			add_scroll_y(
-				Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2, scroll_y
-			), temp_y, temp_room);
+		temp_y = add_scroll_y(
+			Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2,
+			scroll_y
+		);
 }			
 void commonly_stored_routine_2() {
-	storeWordSeparately(
-		add_scroll_y(
-			Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2),
-			scroll_y
-		), temp_y, temp_room);
+	temp_y = add_scroll_y(
+		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2),
+		scroll_y
+	);
 }		
 
 void commonly_used_death_check() {

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -287,7 +287,7 @@ char bg_coll_top_bottom_slabs() {
 			
 
 char bg_coll_mini_blocks() {
-	if (collision != COL_FLOOR_CEIL && high_byte(currplayer_x) < 0x10) return 0;
+	if (collision != COL_FLOOR_CEIL && high_byte(currplayer_relx) < 0x10) return 0;
 	switch (collision) {
 		case COL_UP_LEFT:
 			tmp2 = (uint8_t)(temp_y & 0x0f);	
@@ -444,7 +444,7 @@ char bg_side_coll_common() {
 			}	
 		} else {
 			if (!currplayer_was_on_slope_counter && bg_coll_slope()) {
-				high_byte(currplayer_y) += (currplayer_slope_type & SLOPE_UPSIDEDOWN ? 2 : -2);
+				high_byte(currplayer_rely) += (currplayer_slope_type & SLOPE_UPSIDEDOWN ? 2 : -2);
 			}
 		}
 
@@ -488,7 +488,7 @@ char bg_coll_U_D_checks() {
 		case COL_NO_SIDE:
 			return 1;		
 		case COL_ALL: 
-			if (high_byte(currplayer_x) < 0x10) return 0;
+			if (high_byte(currplayer_relx) < 0x10) return 0;
 			else return 1;
 		case COL_DEATH_TOP:
 			col_death_top_routine();
@@ -887,7 +887,7 @@ char bg_coll_U() {
 	
 	// Slopes
 
-	if (high_byte(currplayer_x) >= 0x10) {
+	if (high_byte(currplayer_relx) >= 0x10) {
 		storeWordSeparately(
 			add_scroll_y(
 				Generic.y + (byte(0x10 - Generic.height) >> 1) + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
@@ -944,7 +944,7 @@ char bg_coll_U() {
 char bg_coll_D() {
 
 	// Slopes
-	if (high_byte(currplayer_x) >= 0x10) {
+	if (high_byte(currplayer_relx) >= 0x10) {
 		storeWordSeparately(
 			add_scroll_y(
 				Generic.y + Generic.height - 2 + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0), scroll_y

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -35,9 +35,6 @@ CODE_BANK_PUSH("XCD_BANK_01")
 	Implemented in asm
 */
 char bg_collision_sub();
-void commonly_used_store();
-void commonly_stored_routine_2();
-void commonly_used_death_check();
 void tmp20f();
 
 
@@ -223,7 +220,10 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// TOP	
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	commonly_used_store();
+	temp_y = add_scroll_y(
+		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2,
+		scroll_y
+	);
 
 	bg_collision_sub();
 
@@ -242,7 +242,10 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// BOTTOM
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	commonly_stored_routine_2();
+	temp_y = add_scroll_y(
+		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2),
+		scroll_y
+	);
 
 	bg_collision_sub();
 
@@ -1072,26 +1075,6 @@ void bg_coll_death() {
 //		reset_level();
 //	}
 }
-
-void commonly_used_store() {
-		temp_y = add_scroll_y(
-			Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2,
-			scroll_y
-		);
-}			
-void commonly_stored_routine_2() {
-	temp_y = add_scroll_y(
-		Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2),
-		scroll_y
-	);
-}		
-
-void commonly_used_death_check() {
-	do_if_in_range((uint8_t)(temp_x & 0x0f), 0x04, 0x08, {
-		cube_data[currplayer] = 1;
-	});
-}
-
 
 CODE_BANK_POP()
 #endif

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -219,7 +219,7 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// TOP	
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	temp_y = calculate_ppufmt_scroll_y(
+	temp_y = (
 		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + Generic.height - 2)
 	);
 
@@ -240,7 +240,7 @@ void bg_coll_floor_spikes() { // used for spike collision
 	// BOTTOM
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
-	temp_y = calculate_ppufmt_scroll_y(
+	temp_y = (
 		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 2))
 	);
 
@@ -432,7 +432,7 @@ char bg_side_coll_common() {
 		return 0;
 	}
 
-	temp_y = calculate_ppufmt_scroll_y(transitional_linear_absolute_currplayer_y + tmp1);
+	temp_y = transitional_linear_absolute_currplayer_y + tmp1;
 
 	bg_collision_sub();
 	if (collision) {
@@ -889,7 +889,7 @@ char bg_coll_U() {
 	// Slopes
 
 	if (high_byte(currplayer_relx) >= 0x10) {
-		temp_y = calculate_ppufmt_scroll_y(
+		temp_y = (
 			transitional_linear_absolute_currplayer_y + (uint8_t)(transitional_sixteen_minus_generic_height_halved + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0))
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
@@ -912,7 +912,7 @@ char bg_coll_U() {
 	if (high_byte(currplayer_vel_y) & 0x80) {
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 		
-		temp_y = calculate_ppufmt_scroll_y(
+		temp_y = (
 			transitional_linear_absolute_currplayer_y + (uint8_t)(((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)))
 		);
 		
@@ -943,7 +943,7 @@ char bg_coll_D() {
 
 	// Slopes
 	if (high_byte(currplayer_relx) >= 0x10) {
-		temp_y = calculate_ppufmt_scroll_y(
+		temp_y = (
 			transitional_linear_absolute_currplayer_y - 2 + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
@@ -966,7 +966,7 @@ char bg_coll_D() {
 		// check 2 points on the right side
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 
-		temp_y = calculate_ppufmt_scroll_y(
+		temp_y = (
 			transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 		);
 
@@ -991,7 +991,7 @@ char bg_coll_D() {
 
 char bg_coll_U_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	temp_y = calculate_ppufmt_scroll_y(
+	temp_y = (
 		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 
@@ -1008,7 +1008,7 @@ char bg_coll_U_spider() {
 
 char bg_coll_D_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
-	temp_y = calculate_ppufmt_scroll_y(
+	temp_y = (
 		transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 	
@@ -1037,7 +1037,7 @@ void bg_coll_death() {
 
 	temp_x = Generic.x + low_word(scroll_x) + (Generic.width >> 1)-1; // automatically only the low byte
 
-	temp_y = calculate_ppufmt_scroll_y(
+	temp_y = (
 		transitional_linear_absolute_currplayer_y + (uint8_t)((Generic.height >> 1) + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 

--- a/SAUCE/functions/collision.h
+++ b/SAUCE/functions/collision.h
@@ -220,7 +220,7 @@ void bg_coll_floor_spikes() { // used for spike collision
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
 	temp_y = calculate_ppufmt_scroll_y(
-		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + Generic.height - 2)
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + Generic.height - 2)
 	);
 
 	bg_collision_sub();
@@ -241,7 +241,7 @@ void bg_coll_floor_spikes() { // used for spike collision
 	temp_x = Generic.x + low_word(scroll_x) + 3; // automatically only the low byte
 
 	temp_y = calculate_ppufmt_scroll_y(
-		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 2))
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 2))
 	);
 
 	bg_collision_sub();
@@ -422,7 +422,7 @@ char bg_coll_slope();
 
 */
 char bg_side_coll_common() {
-	tmp1 = Generic.y + (currplayer_mini ? (byte(0x10 - Generic.height) >> 1) : 0) + (Generic.height >> 1);
+	tmp1 = Generic.y + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (Generic.height >> 1);
 
 	if (currplayer_mini && (gamemode == GAMEMODE_CUBE || gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA)) {
 		tmp1 += (currplayer_gravity ? 3 : -2);
@@ -889,7 +889,7 @@ char bg_coll_U() {
 
 	if (high_byte(currplayer_relx) >= 0x10) {
 		temp_y = add_scroll_y(
-			Generic.y + (byte(0x10 - Generic.height) >> 1) + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
+			Generic.y + transitional_sixteen_minus_generic_height_halved + (currplayer_mini ? 1 : 2) + (gamemode == GAMEMODE_SHIP ? 1 : 0),
 			scroll_y
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
@@ -913,7 +913,7 @@ char bg_coll_U() {
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 		
 		temp_y = add_scroll_y(
-			Generic.y + ((currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)),
+			Generic.y + ((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 0 : 1)),
 			scroll_y
 		);
 		
@@ -944,7 +944,7 @@ char bg_coll_D() {
 	// Slopes
 	if (high_byte(currplayer_relx) >= 0x10) {
 		temp_y = add_scroll_y(
-			Generic.y + Generic.height - 2 + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+			Generic.y + Generic.height - 2 + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
 			scroll_y
 		);
 		temp_x = Generic.x + low_word(scroll_x); // middle of the cube
@@ -968,7 +968,7 @@ char bg_coll_D() {
 		temp_x = Generic.x + low_word(scroll_x) + (gamemode == GAMEMODE_WAVE || gamemode == GAMEMODE_SNAKE ? 4 : 0); // automatically only the low byte
 
 		temp_y = add_scroll_y(
-			Generic.y + Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+			Generic.y + Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
 			scroll_y
 		);
 
@@ -994,7 +994,7 @@ char bg_coll_D() {
 char bg_coll_U_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
 	temp_y = calculate_ppufmt_scroll_y(
-		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0))
+		transitional_linear_absolute_currplayer_y + (uint8_t)((currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 
 	tmp8 = (temp_y) & 0x0f;
@@ -1011,7 +1011,7 @@ char bg_coll_U_spider() {
 char bg_coll_D_spider() {
 	temp_x = LEFT_POS; // automatically only the low byte
 	temp_y = calculate_ppufmt_scroll_y(
-		transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0))
+		transitional_linear_absolute_currplayer_y + (uint8_t)(Generic.height + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0))
 	);
 	
 	tmp8 = (temp_y) & 0x0f;
@@ -1040,7 +1040,7 @@ void bg_coll_death() {
 	temp_x = Generic.x + low_word(scroll_x) + (Generic.width >> 1)-1; // automatically only the low byte
 
 	temp_y = add_scroll_y(
-		Generic.y + (Generic.height >> 1) + (currplayer_mini ? byte(0x10 - Generic.height) >> 1 : 0),
+		Generic.y + (Generic.height >> 1) + (currplayer_mini ? transitional_sixteen_minus_generic_height_halved : 0),
 		scroll_y
 	);
 

--- a/SAUCE/functions/draw_sprites.h
+++ b/SAUCE/functions/draw_sprites.h
@@ -181,21 +181,21 @@ void draw_sprites(){
 			skipProcessingCubeRotationLogic++;
 			tmp6 = currplayer_vel_x << 1;
 			
-			tmpA = player_x[0];
-			tmpB = player_y[0];
+			tmpA = player_relx[0];
+			tmpB = player_rely[0];
 
-			high_byte(player_x[0]) -= high_byte(tmp6);
-			high_byte(player_y[0]) = player_old_posy[0];
+			high_byte(player_relx[0]) -= high_byte(tmp6);
+			high_byte(player_rely[0]) = player_old_posy[0];
 
 			crossPRGBankJump0(drawplayerone);
 			
-			high_byte(player_x[0]) -= high_byte(tmp6);
-			high_byte(player_y[0]) = player_old_posy[1];
+			high_byte(player_relx[0]) -= high_byte(tmp6);
+			high_byte(player_rely[0]) = player_old_posy[1];
 
 			crossPRGBankJump0(drawplayerone);
 
-			high_byte(player_x[0]) -= high_byte(tmp6);
-			high_byte(player_y[0]) = player_old_posy[2];
+			high_byte(player_relx[0]) -= high_byte(tmp6);
+			high_byte(player_rely[0]) = player_old_posy[2];
 
 			if (gamemode == GAMEMODE_CUBE) {
 				tmp9 = currplayer_mini;
@@ -208,8 +208,8 @@ void draw_sprites(){
 				currplayer_mini = tmp9;
 			}
 			
-			player_x[0] = tmpA;
-			player_y[0] = tmpB;
+			player_relx[0] = tmpA;
+			player_rely[0] = tmpB;
 			skipProcessingCubeRotationLogic--;		
 		}
 	}
@@ -222,7 +222,7 @@ void trail_loop() {
 	if (kandoframecnt & 1) {
 		tmp6 = currplayer_vel_x << 1;
 		tmp1 = 1;
-		tmp5 = currplayer_x - tmp6;
+		tmp5 = currplayer_relx - tmp6;
 		do {
 			if (trail_sprites_visible[tmp1]) {	
 				oam_spr(
@@ -238,7 +238,7 @@ void trail_loop() {
 		tmp1 = 7;
 		// the following 2 lines of code are equal to tmp5 -= (tmp6 * 7)
 		tmp5 = currplayer_vel_x << 4;
-		tmp5 = (currplayer_vel_x << 1) + currplayer_x - tmp5;
+		tmp5 = (currplayer_vel_x << 1) + currplayer_relx - tmp5;
 		do {
 			if (trail_sprites_visible[tmp1]) {
 				oam_spr(
@@ -262,19 +262,19 @@ void put_number() {
 }
 
 void minus15y() {
-	high_byte(player_y[0]) -= 15;
+	high_byte(player_rely[0]) -= 15;
 }
 
 void minus15x() {
-	high_byte(player_x[0]) -= 15;
+	high_byte(player_relx[0]) -= 15;
 }
 
 void plus15y() {
-	high_byte(player_y[0]) += 15;
+	high_byte(player_rely[0]) += 15;
 }
 
 void plus15x() {
-	high_byte(player_x[0]) += 15;
+	high_byte(player_relx[0]) += 15;
 }
 
 

--- a/SAUCE/functions/draw_sprites.h
+++ b/SAUCE/functions/draw_sprites.h
@@ -58,8 +58,8 @@ void draw_sprites(){
 		if (temp_x > 0xf0) continue;
 		if (temp_x == 0) temp_x = 1;
 
-		temp_y = activesprites_realy[index];
-		if (temp_y > 0xf0) continue;
+		low_byte(temp_y) = activesprites_realy[index];
+		if (low_byte(temp_y) > 0xf0) continue;
 
 		#define animation_frame_count tmp1
 		#define animation_frame tmp2

--- a/SAUCE/functions/draw_sprites.h
+++ b/SAUCE/functions/draw_sprites.h
@@ -185,17 +185,17 @@ void draw_sprites(){
 			tmpB = player_rely[0];
 
 			high_byte(player_relx[0]) -= high_byte(tmp6);
-			high_byte(player_rely[0]) = player_old_posy[0];
+			high_byte(player_rely[0]) = player_old_rely[0];
 
 			crossPRGBankJump0(drawplayerone);
 			
 			high_byte(player_relx[0]) -= high_byte(tmp6);
-			high_byte(player_rely[0]) = player_old_posy[1];
+			high_byte(player_rely[0]) = player_old_rely[1];
 
 			crossPRGBankJump0(drawplayerone);
 
 			high_byte(player_relx[0]) -= high_byte(tmp6);
-			high_byte(player_rely[0]) = player_old_posy[2];
+			high_byte(player_rely[0]) = player_old_rely[2];
 
 			if (gamemode == GAMEMODE_CUBE) {
 				tmp9 = currplayer_mini;
@@ -227,7 +227,7 @@ void trail_loop() {
 			if (trail_sprites_visible[tmp1]) {	
 				oam_spr(
 					high_byte(tmp5) + Trail_Circ_X,
-					player_old_posy[tmp1] + Trail_Circ_Y,
+					player_old_rely[tmp1] + Trail_Circ_Y,
 					Trail_Circ_CHR, Trail_Circ_Attr);
 			}
 			
@@ -243,7 +243,7 @@ void trail_loop() {
 			if (trail_sprites_visible[tmp1]) {
 				oam_spr(
 					high_byte(tmp5) + Trail_Circ_X,
-					player_old_posy[tmp1] + Trail_Circ_Y,
+					player_old_rely[tmp1] + Trail_Circ_Y,
 					Trail_Circ_CHR, Trail_Circ_Attr);
 			}
 			

--- a/SAUCE/functions/level_loading.h
+++ b/SAUCE/functions/level_loading.h
@@ -138,7 +138,7 @@ void unrle_first_screen(){ // run-length decode the first screen of a level
 	init_sprites();
 	
 	set_scroll_x(scroll_x);
-	set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
+	set_scroll_y(calculate_ppufmt_scroll_y(scroll_y));
 //	if (!practice_point_count) {
 		#if !__VS_SYSTEM
 			multi_vram_buffer_horz((const char*)attempttext,sizeof(attempttext)-1,NTADR_C(6, 15));

--- a/SAUCE/functions/level_loading.h
+++ b/SAUCE/functions/level_loading.h
@@ -138,7 +138,7 @@ void unrle_first_screen(){ // run-length decode the first screen of a level
 	init_sprites();
 	
 	set_scroll_x(scroll_x);
-	set_scroll_y(scroll_y);
+	set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
 //	if (!practice_point_count) {
 		#if !__VS_SYSTEM
 			multi_vram_buffer_horz((const char*)attempttext,sizeof(attempttext)-1,NTADR_C(6, 15));

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -62,7 +62,7 @@ void store_practice_state(){
 	idx8_store(practice_player_2_last_slope_type, get_Y, last_slope_type[1]);
 
 	lohi_arr32_store_from(practice_scroll_x, get_Y, scroll_x);
-	lohi_arr16_store(practice_scroll_y, get_Y, scroll_y);
+	lohi_arr16_store(practice_scroll_y, get_Y, linear_scroll_y);
 	idx8_store(practice_scroll_y_subpx, get_Y, scroll_y_subpx);
 	lohi_arr16_store(practice_seam_scroll_y, get_Y, ppufmt_seam_scroll_y);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
@@ -141,7 +141,7 @@ void load_practice_state() {
 	last_slope_type[1] = idx8_load(practice_player_2_last_slope_type, get_Y);
 
 	lohi_arr32_load_to(practice_scroll_x, get_Y, scroll_x);
-	scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
+	old_trail_scroll_y = linear_scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
 	ppufmt_seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
@@ -169,8 +169,8 @@ void load_practice_state() {
 
 	scroll_x -= (256 + 16);
 
-	// LAZY LINEAR INSERT!
-	old_trail_scroll_y = linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+	// LAZY LINEAR INSERT! (but role reversed)
+	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 
 	tmp3 = (lastbgcolortype & 0x3F);
 	pal_col(0, tmp3);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -62,7 +62,7 @@ void store_practice_state(){
 	idx8_store(practice_player_2_last_slope_type, get_Y, last_slope_type[1]);
 
 	lohi_arr32_store_from(practice_scroll_x, get_Y, scroll_x);
-	lohi_arr16_store(practice_scroll_y, get_Y, linear_scroll_y);
+	lohi_arr16_store(practice_scroll_y, get_Y, scroll_y);
 	idx8_store(practice_scroll_y_subpx, get_Y, scroll_y_subpx);
 	lohi_arr16_store(practice_seam_scroll_y, get_Y, ppufmt_seam_scroll_y);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
@@ -141,7 +141,7 @@ void load_practice_state() {
 	last_slope_type[1] = idx8_load(practice_player_2_last_slope_type, get_Y);
 
 	lohi_arr32_load_to(practice_scroll_x, get_Y, scroll_x);
-	old_trail_scroll_y = linear_scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
+	old_trail_scroll_y = scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
 	ppufmt_seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -13,6 +13,7 @@ const uint8_t multStateLookup_hi[] = {
 };
 
 extern uint16_t old_draw_scroll_y, seam_scroll_y;
+extern uint8_t seam_absent;
 
 extern uint8_t famistudio_state[FAMISTUDIO_STATE_SIZE];
 extern uint8_t famistudio_output_buf[FAMISTUDIO_OUTPUT_BUF_SIZE];
@@ -167,7 +168,8 @@ void load_practice_state() {
 	lastgcolortype = idx8_load(practice_g_color_type, get_Y);
 	lastbgcolortype = idx8_load(practice_bg_color_type, get_Y);
 
-	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
+	ppufmt_seam_scroll_y = ((int16_t)seam_scroll_y) < 0 ? seam_scroll_y : calculate_ppufmt_scroll_y(seam_scroll_y);
+	__asm__("lda %v+1 \n cmp #%b \n ror %v", ppufmt_seam_scroll_y, 2, seam_absent);
 
 	scroll_x -= (256 + 16);
 

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -156,7 +156,7 @@ void load_practice_state() {
 //	tmp2 = 0;
 //	do {
 //		idx8_store(trail_sprites_visible, tmp2, practice_trail_sprites_visible[tmp2]);
-//		idx8_store(player_old_posy, tmp2, practice_player_old_posy[tmp2]);
+//		idx8_store(player_old_rely, tmp2, practice_player_old_rely[tmp2]);
 //	} while (++tmp2 < 9);
 	nullscapes_active = idx8_load(practice_nullscapes_active, get_Y);
 	nullscapes_orb_type = idx8_load(practice_nullscapes_orb_type, get_Y);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -67,7 +67,7 @@ void store_practice_state(){
 	lohi_arr16_store(practice_seam_scroll_y, get_Y, seam_scroll_y);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
 	lohi_arr16_store(practice_target_scroll_y, get_Y, target_scroll_y);
-	lohi_arr16_store(practice_min_scroll_y, get_Y, min_scroll_y);
+	lohi_arr16_store(practice_min_scroll_y, get_Y, min_scroll_y);	// notably this one is useless
 
 	idx8_store(practice_player_invis, get_Y, player_invis);
 	idx8_store(practice_player_gamemode, get_Y, gamemode);
@@ -146,7 +146,7 @@ void load_practice_state() {
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
 	seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
 	target_scroll_y = lohi_arr16_load(practice_target_scroll_y, get_Y);
-	min_scroll_y = lohi_arr16_load(practice_min_scroll_y, get_Y);
+	min_scroll_y = lohi_arr16_load(practice_min_scroll_y, get_Y);	// notably this one is useless
 
 	player_invis = idx8_load(practice_player_invis, get_Y);
 	gamemode = idx8_load(practice_player_gamemode, get_Y);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -169,9 +169,6 @@ void load_practice_state() {
 
 	scroll_x -= (256 + 16);
 
-	// LAZY LINEAR INSERT! (but role reversed)
-	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
-
 	tmp3 = (lastbgcolortype & 0x3F);
 	pal_col(0, tmp3);
 	pal_col(0x0D, tmp3);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -141,7 +141,7 @@ void load_practice_state() {
 	last_slope_type[1] = idx8_load(practice_player_2_last_slope_type, get_Y);
 
 	lohi_arr32_load_to(practice_scroll_x, get_Y, scroll_x);
-	old_trail_scroll_y = scroll_y =	lohi_arr16_load(practice_scroll_y, get_Y);
+	scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
 	seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
@@ -170,7 +170,7 @@ void load_practice_state() {
 	scroll_x -= (256 + 16);
 
 	// LAZY LINEAR INSERT!
-	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+	old_trail_scroll_y = linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 
 	tmp3 = (lastbgcolortype & 0x3F);
 	pal_col(0, tmp3);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -169,6 +169,9 @@ void load_practice_state() {
 
 	scroll_x -= (256 + 16);
 
+	// LAZY LINEAR INSERT!
+	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+
 	tmp3 = (lastbgcolortype & 0x3F);
 	pal_col(0, tmp3);
 	pal_col(0x0D, tmp3);

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -12,8 +12,7 @@ const uint8_t multStateLookup_hi[] = {
 	MSB(4*FAMISTUDIO_STATE_SIZE),	MSB(5*FAMISTUDIO_STATE_SIZE),	MSB(6*FAMISTUDIO_STATE_SIZE),	MSB(7*FAMISTUDIO_STATE_SIZE),
 };
 
-extern uint16_t old_draw_scroll_y, seam_scroll_y;
-extern uint8_t seam_absent;
+extern uint16_t old_draw_scroll_y, seam_position;
 
 extern uint8_t famistudio_state[FAMISTUDIO_STATE_SIZE];
 extern uint8_t famistudio_output_buf[FAMISTUDIO_OUTPUT_BUF_SIZE];
@@ -65,7 +64,7 @@ void store_practice_state(){
 	lohi_arr32_store_from(practice_scroll_x, get_Y, scroll_x);
 	lohi_arr16_store(practice_scroll_y, get_Y, scroll_y);
 	idx8_store(practice_scroll_y_subpx, get_Y, scroll_y_subpx);
-	lohi_arr16_store(practice_seam_scroll_y, get_Y, seam_scroll_y);
+	lohi_arr16_store(practice_seam_position, get_Y, seam_position);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
 	lohi_arr16_store(practice_target_scroll_y, get_Y, target_scroll_y);
 	lohi_arr16_store(practice_min_scroll_y, get_Y, min_scroll_y);	// notably this one is useless
@@ -145,7 +144,7 @@ void load_practice_state() {
 	old_trail_scroll_y = scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
-	seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
+	seam_position = lohi_arr16_load(practice_seam_position, get_Y);
 	target_scroll_y = lohi_arr16_load(practice_target_scroll_y, get_Y);
 	min_scroll_y = lohi_arr16_load(practice_min_scroll_y, get_Y);	// notably this one is useless
 
@@ -168,8 +167,8 @@ void load_practice_state() {
 	lastgcolortype = idx8_load(practice_g_color_type, get_Y);
 	lastbgcolortype = idx8_load(practice_bg_color_type, get_Y);
 
-	ppufmt_seam_scroll_y = ((int16_t)seam_scroll_y) < 0 ? seam_scroll_y : calculate_ppufmt_scroll_y(seam_scroll_y);
-	__asm__("lda %v+1 \n cmp #%b \n ror %v", ppufmt_seam_scroll_y, 2, seam_absent);
+	__A__ = seam_position_screen = MSB(((int16_t)seam_position) < 0 ? seam_position : calculate_ppufmt_scroll_y(seam_position));
+	__asm__("cmp #%b \n ror %v", 2, seam_absent);
 
 	scroll_x -= (256 + 16);
 

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -64,7 +64,7 @@ void store_practice_state(){
 	lohi_arr32_store_from(practice_scroll_x, get_Y, scroll_x);
 	lohi_arr16_store(practice_scroll_y, get_Y, scroll_y);
 	idx8_store(practice_scroll_y_subpx, get_Y, scroll_y_subpx);
-	lohi_arr16_store(practice_seam_scroll_y, get_Y, seam_scroll_y);
+	lohi_arr16_store(practice_seam_scroll_y, get_Y, ppufmt_seam_scroll_y);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
 	lohi_arr16_store(practice_target_scroll_y, get_Y, target_scroll_y);
 	lohi_arr16_store(practice_min_scroll_y, get_Y, min_scroll_y);	// notably this one is useless
@@ -144,7 +144,7 @@ void load_practice_state() {
 	scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
-	seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
+	ppufmt_seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
 	target_scroll_y = lohi_arr16_load(practice_target_scroll_y, get_Y);
 	min_scroll_y = lohi_arr16_load(practice_min_scroll_y, get_Y);	// notably this one is useless
 

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -12,7 +12,7 @@ const uint8_t multStateLookup_hi[] = {
 	MSB(4*FAMISTUDIO_STATE_SIZE),	MSB(5*FAMISTUDIO_STATE_SIZE),	MSB(6*FAMISTUDIO_STATE_SIZE),	MSB(7*FAMISTUDIO_STATE_SIZE),
 };
 
-extern uint16_t old_draw_scroll_y;
+extern uint16_t old_draw_scroll_y, seam_scroll_y;
 
 extern uint8_t famistudio_state[FAMISTUDIO_STATE_SIZE];
 extern uint8_t famistudio_output_buf[FAMISTUDIO_OUTPUT_BUF_SIZE];
@@ -64,7 +64,7 @@ void store_practice_state(){
 	lohi_arr32_store_from(practice_scroll_x, get_Y, scroll_x);
 	lohi_arr16_store(practice_scroll_y, get_Y, scroll_y);
 	idx8_store(practice_scroll_y_subpx, get_Y, scroll_y_subpx);
-	lohi_arr16_store(practice_seam_scroll_y, get_Y, ppufmt_seam_scroll_y);
+	lohi_arr16_store(practice_seam_scroll_y, get_Y, seam_scroll_y);
 	lohi_arr16_store(practice_old_draw_scroll_y, get_Y, old_draw_scroll_y);
 	lohi_arr16_store(practice_target_scroll_y, get_Y, target_scroll_y);
 	lohi_arr16_store(practice_min_scroll_y, get_Y, min_scroll_y);	// notably this one is useless
@@ -144,7 +144,7 @@ void load_practice_state() {
 	old_trail_scroll_y = scroll_y = lohi_arr16_load(practice_scroll_y, get_Y);
 	scroll_y_subpx = idx8_load(practice_scroll_y_subpx, get_Y);
 	old_draw_scroll_y = lohi_arr16_load(practice_old_draw_scroll_y, get_Y);
-	ppufmt_seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
+	seam_scroll_y = lohi_arr16_load(practice_seam_scroll_y, get_Y);
 	target_scroll_y = lohi_arr16_load(practice_target_scroll_y, get_Y);
 	min_scroll_y = lohi_arr16_load(practice_min_scroll_y, get_Y);	// notably this one is useless
 
@@ -166,6 +166,8 @@ void load_practice_state() {
 
 	lastgcolortype = idx8_load(practice_g_color_type, get_Y);
 	lastbgcolortype = idx8_load(practice_bg_color_type, get_Y);
+
+	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
 
 	scroll_x -= (256 + 16);
 

--- a/SAUCE/functions/practice_state.h
+++ b/SAUCE/functions/practice_state.h
@@ -35,10 +35,10 @@ void store_practice_state(){
 	tmp1 = latest_practice_point;
 
 	curr_practice_point = latest_practice_point;
-	lohi_arr16_store(practice_player_1_x, tmp1, player_x[0]);
-	lohi_arr16_store(practice_player_2_x, get_Y, player_x[1]);
-	lohi_arr16_store(practice_player_1_y, get_Y, player_y[0]);
-	lohi_arr16_store(practice_player_2_y, get_Y, player_y[1]);
+	lohi_arr16_store(practice_player_1_x, tmp1, player_relx[0]);
+	lohi_arr16_store(practice_player_2_x, get_Y, player_relx[1]);
+	lohi_arr16_store(practice_player_1_y, get_Y, player_rely[0]);
+	lohi_arr16_store(practice_player_2_y, get_Y, player_rely[1]);
 	lohi_arr16_store(practice_player_1_vel_x, get_Y, player_vel_x[0]);
 	lohi_arr16_store(practice_player_2_vel_x, get_Y, player_vel_x[1]);
 	lohi_arr16_store(practice_player_1_vel_y, get_Y, player_vel_y[0]);
@@ -90,7 +90,7 @@ void store_practice_state(){
 		memcpy(practice_famistudio_state + lohi_arr16_load(multStateLookup, tmp1), famistudio_state, FAMISTUDIO_STATE_SIZE);
 		memcpy(practice_famistudio_registers + multBufLookup[tmp1], famistudio_output_buf, FAMISTUDIO_OUTPUT_BUF_SIZE);
     }
-	practice_sprite_x_pos = high_byte(player_x[0]);
+	practice_sprite_x_pos = high_byte(player_relx[0]);
 	auto_practicepoint_timer = 200;
 #endif
 }
@@ -99,10 +99,10 @@ void store_practice_state(){
 void load_practice_state() {
 #if !__VS_SYSTEM
 	tmp2 = curr_practice_point;
-	player_x[0] = lohi_arr16_load(practice_player_1_x, tmp2);
-	player_x[1] = lohi_arr16_load(practice_player_2_x, get_Y);
-	player_y[0] = lohi_arr16_load(practice_player_1_y, get_Y);
-	player_y[1] = lohi_arr16_load(practice_player_2_y, get_Y);
+	player_relx[0] = lohi_arr16_load(practice_player_1_x, tmp2);
+	player_relx[1] = lohi_arr16_load(practice_player_2_x, get_Y);
+	player_rely[0] = lohi_arr16_load(practice_player_1_y, get_Y);
+	player_rely[1] = lohi_arr16_load(practice_player_2_y, get_Y);
 	player_vel_x[0] = lohi_arr16_load(practice_player_1_vel_x, get_Y);
 	player_vel_x[1] = lohi_arr16_load(practice_player_2_vel_x, get_Y);
 	player_vel_y[0] = lohi_arr16_load(practice_player_1_vel_y, get_Y);
@@ -191,8 +191,8 @@ void load_practice_state() {
 	__asm__("tay");
 	#define quick_ld(to, from) __asm__("lda %v,y\n sta %v\n lda %v+1,y\n sta %v+1", from, to, from, to)
 	
-	quick_ld(currplayer_x, player_x);
-	quick_ld(currplayer_y, player_y);
+	quick_ld(currplayer_relx, player_relx);
+	quick_ld(currplayer_rely, player_rely);
 	quick_ld(currplayer_vel_x, player_vel_x);
 	quick_ld(currplayer_vel_y, player_vel_y);
 

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -67,13 +67,11 @@ void reset_level() {
 
 	linear_scroll_y = spawn_scroll_y_pos;
 	seam_scroll_y = (linear_scroll_y - 0x78);
-	// LAZY LINEAR INSERT! (but role reversed)
 	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
-	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 	// slope stuff
 	scroll_y_subpx = 0;
 	set_scroll_x(scroll_x);
-	set_scroll_y(scroll_y);
+	set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
 
 	currplayer_was_on_slope_counter = 0;
 	was_on_slope_counter[0] = 0;

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -70,6 +70,8 @@ void reset_level() {
 	init_rld(level);
 
 	scroll_y = spawn_scroll_y_pos;
+	// LAZY LINEAR INSERT!
+	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 	scroll_y_subpx = 0;
 	currplayer_was_on_slope_counter = 0;
 	was_on_slope_counter[0] = 0;

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -66,9 +66,10 @@ void reset_level() {
 	init_rld(level);
 
 	linear_scroll_y = spawn_scroll_y_pos;
+	seam_scroll_y = (linear_scroll_y - 0x78);
 	// LAZY LINEAR INSERT! (but role reversed)
+	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
 	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
-	seam_scroll_y = (scroll_y - 0x78); // [temp]
 	// slope stuff
 	scroll_y_subpx = 0;
 	set_scroll_x(scroll_x);

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -66,8 +66,9 @@ void reset_level() {
 	init_rld(level);
 
 	scroll_y = spawn_scroll_y_pos;
-	seam_scroll_y = (scroll_y - 0x78);
-	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
+	seam_position = (scroll_y - 0x78);
+	__A__ = seam_position_screen = MSB(((int16_t)seam_position) < 0 ? seam_position : calculate_ppufmt_scroll_y(seam_position));
+	__asm__("cmp #%b \n ror %v", 2, seam_absent);
 	// slope stuff
 	scroll_y_subpx = 0;
 	set_scroll_x(scroll_x);

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -69,9 +69,9 @@ void reset_level() {
 	set_scroll_y(scroll_y);
 	init_rld(level);
 
-	scroll_y = spawn_scroll_y_pos;
-	// LAZY LINEAR INSERT!
-	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+	linear_scroll_y = spawn_scroll_y_pos;
+	// LAZY LINEAR INSERT! (but role reversed)
+	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 	scroll_y_subpx = 0;
 	currplayer_was_on_slope_counter = 0;
 	was_on_slope_counter[0] = 0;

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -63,16 +63,17 @@ void reset_level() {
 	#if !__VS_SYSTEM
 	gameState = STATE_GAME; //fix for dying as the end trigger triggers
 	#endif
-	// slope stuff
-	seam_scroll_y = (0x2EF - 0x78); // [temp]
-	set_scroll_x(scroll_x);
-	set_scroll_y(scroll_y);
 	init_rld(level);
 
 	linear_scroll_y = spawn_scroll_y_pos;
 	// LAZY LINEAR INSERT! (but role reversed)
 	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
+	seam_scroll_y = (scroll_y - 0x78); // [temp]
+	// slope stuff
 	scroll_y_subpx = 0;
+	set_scroll_x(scroll_x);
+	set_scroll_y(scroll_y);
+
 	currplayer_was_on_slope_counter = 0;
 	was_on_slope_counter[0] = 0;
 	was_on_slope_counter[1] = 0;
@@ -146,7 +147,7 @@ void reset_level() {
 	player_rely[1] = spawn_y_pos;
 	currplayer_rely = spawn_y_pos;
 
-	target_scroll_y = spawn_y_pos;
+	target_scroll_y = linear_scroll_y;
 
 	player_gravity[1] = twoplayer ? GRAVITY_DOWN : GRAVITY_UP;
 

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -167,7 +167,7 @@ void reset_level() {
 	curr_x_scroll_stop = 0x5000;
 	target_x_scroll_stop = 0x5000;
 	if (!practice_point_count) {
-		memfill(player_old_posy, 0, sizeof(player_old_posy));
+		memfill(player_old_rely, 0, sizeof(player_old_rely));
 		memfill(trail_sprites_visible, 0, sizeof(trail_sprites_visible));
 		invincible_counter = 8;
 	}

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -65,13 +65,13 @@ void reset_level() {
 	#endif
 	init_rld(level);
 
-	linear_scroll_y = spawn_scroll_y_pos;
-	seam_scroll_y = (linear_scroll_y - 0x78);
+	scroll_y = spawn_scroll_y_pos;
+	seam_scroll_y = (scroll_y - 0x78);
 	ppufmt_seam_scroll_y = calculate_ppufmt_scroll_y(seam_scroll_y);
 	// slope stuff
 	scroll_y_subpx = 0;
 	set_scroll_x(scroll_x);
-	set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
+	set_scroll_y(calculate_ppufmt_scroll_y(scroll_y));
 
 	currplayer_was_on_slope_counter = 0;
 	was_on_slope_counter[0] = 0;
@@ -146,7 +146,7 @@ void reset_level() {
 	player_rely[1] = spawn_y_pos;
 	currplayer_rely = spawn_y_pos;
 
-	target_scroll_y = linear_scroll_y;
+	target_scroll_y = scroll_y;
 
 	player_gravity[1] = twoplayer ? GRAVITY_DOWN : GRAVITY_UP;
 

--- a/SAUCE/functions/reset_level.h
+++ b/SAUCE/functions/reset_level.h
@@ -28,8 +28,8 @@ void death_animation() {
 			if (robotjumpframe[0] < 20) {
 				if (retro_mode && !(gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA || gamemode == GAMEMODE_UFO || gamemode == GAMEMODE_SHIP)) mmc3_set_2kb_chr_bank_0(20);	//default set for explosion
 				oam_meta_spr(
-					idx16_load_hi_NOC(player_x, tmp2)-2,
-					idx16_load_hi_NOC(player_y, tmp2)-2,
+					idx16_load_hi_NOC(player_relx, tmp2)-2,
+					idx16_load_hi_NOC(player_rely, tmp2)-2,
 					(retro_mode && (gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA || gamemode == GAMEMODE_UFO || gamemode == GAMEMODE_SHIP)) ? ExplodeR_Sprites[robotjumpframe[0] & 0x7F] :
 					Explode_Sprites[robotjumpframe[0] & 0x7F]);
 				++robotjumpframe[0];
@@ -140,9 +140,9 @@ void reset_level() {
 	} while (++tmp1 < max_loaded_sprites);
 
 
-	player_y[0] = spawn_y_pos;
-	player_y[1] = spawn_y_pos;
-	currplayer_y = spawn_y_pos;
+	player_rely[0] = spawn_y_pos;
+	player_rely[1] = spawn_y_pos;
+	currplayer_rely = spawn_y_pos;
 
 	target_scroll_y = spawn_y_pos;
 
@@ -155,13 +155,13 @@ void reset_level() {
 	#endif
 
 	if (!(options & platformer) && !force_platformer) {
-	player_x[0] = 0x0000;
-	player_x[1] = 0x0000;
-	currplayer_x = 0x0000;
+	player_relx[0] = 0x0000;
+	player_relx[1] = 0x0000;
+	currplayer_relx = 0x0000;
 	} else {
-	player_x[0] = 0x1110;
-	player_x[1] = 0x1110;
-	currplayer_x = 0x1110;
+	player_relx[0] = 0x1110;
+	player_relx[1] = 0x1110;
+	currplayer_relx = 0x1110;
 	}
 
 	curr_x_scroll_stop = 0x5000;

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -72,6 +72,8 @@ void process_y_scroll() {
 				scroll_y_subpx -= LSB(cc65_ptr1);
 				do_if_borrow({++high_byte(cc65_ptr1);});
 				scroll_y = sub_scroll_y(MSB(cc65_ptr1), scroll_y);
+				// LAZY LINEAR INSERT!
+				linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 			}
 			cap_scroll_y_at_top();
 
@@ -88,6 +90,8 @@ void process_y_scroll() {
 				scroll_y_subpx += LSB(cc65_ptr1);
 				do_if_carry({++high_byte(cc65_ptr1);});
 				scroll_y = add_scroll_y(MSB(cc65_ptr1), scroll_y);
+				// LAZY LINEAR INSERT!
+				linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 			}
 			cap_scroll_y_at_bottom();
 	} else {			//ship stuff
@@ -114,6 +118,9 @@ void process_y_scroll() {
 			do_if_carry({++high_byte(cc65_ptr1);});
 			scroll_y = sub_scroll_y(MSB(cc65_ptr1), scroll_y);
 		}
+
+		// LAZY LINEAR INSERT!
+		linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 		cap_scroll_y_at_top();
 		cap_scroll_y_at_bottom();
 	}

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -2,11 +2,11 @@
 CODE_BANK_PUSH(SCROLL_BANK)
 
 
-#define player0_x currplayer_x
-#define player1_x player_x[1]
+#define player0_x currplayer_relx
+#define player1_x player_relx[1]
 
-#define player0_y currplayer_y
-#define player1_y player_y[1]
+#define player0_y currplayer_rely
+#define player1_y player_rely[1]
 
 void process_x_scroll() {
 	switch (cam_seesaw) {

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -72,8 +72,6 @@ void process_y_scroll() {
 				scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
 				do_if_borrow({++high_byte(cc65_ptr1);});
 				linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
-				// LAZY LINEAR INSERT! (but role reversed)
-				scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 			}
 			cap_scroll_y_at_top();
 
@@ -90,8 +88,6 @@ void process_y_scroll() {
 				scroll_y_subpx = scroll_y_subpx + LSB(cc65_ptr1);
 				do_if_carry({++high_byte(cc65_ptr1);});
 				linear_scroll_y = linear_scroll_y + MSB(cc65_ptr1);
-				// LAZY LINEAR INSERT! (but role reversed)
-				scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 			}
 			cap_scroll_y_at_bottom();
 	} else {			//ship stuff
@@ -116,8 +112,6 @@ void process_y_scroll() {
 			linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
 		}
 
-		// LAZY LINEAR INSERT! (but role reversed)
-		scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 		cap_scroll_y_at_top();
 		cap_scroll_y_at_bottom();
 	}
@@ -128,7 +122,7 @@ void do_the_scroll_thing(){
 	process_y_scroll();
 
     set_scroll_x(scroll_x);
-    set_scroll_y(scroll_y);
+    set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
 }
 
 

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -69,15 +69,15 @@ void process_y_scroll() {
 				player0_y += cc65_ptr1;
 				player1_y += cc65_ptr1;
 
-				scroll_y_subpx -= LSB(cc65_ptr1);
+				scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
 				do_if_borrow({++high_byte(cc65_ptr1);});
-				scroll_y = sub_scroll_y(MSB(cc65_ptr1), scroll_y);
-				// LAZY LINEAR INSERT!
-				linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+				linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
+				// LAZY LINEAR INSERT! (but role reversed)
+				scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 			}
 			cap_scroll_y_at_top();
 
-			if (scroll_y < 0x2EF && high_byte(player0_y) >= MSB(0xA000)){
+			if (linear_scroll_y < 0x2CF && high_byte(player0_y) >= MSB(0xA000)){
 				// change y scroll (downward)
 				cc65_ptr1 = player0_y - 0xA000;
 				if (exitPortalTimer) {
@@ -87,11 +87,11 @@ void process_y_scroll() {
 				player0_y = player0_y - cc65_ptr1;
 				player1_y = player1_y - cc65_ptr1;
 
-				scroll_y_subpx += LSB(cc65_ptr1);
+				scroll_y_subpx = scroll_y_subpx + LSB(cc65_ptr1);
 				do_if_carry({++high_byte(cc65_ptr1);});
-				scroll_y = add_scroll_y(MSB(cc65_ptr1), scroll_y);
-				// LAZY LINEAR INSERT!
-				linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+				linear_scroll_y = linear_scroll_y + MSB(cc65_ptr1);
+				// LAZY LINEAR INSERT! (but role reversed)
+				scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 			}
 			cap_scroll_y_at_bottom();
 	} else {			//ship stuff
@@ -101,9 +101,9 @@ void process_y_scroll() {
 			player0_y = player0_y - cc65_ptr1;
 			player1_y = player1_y - cc65_ptr1;
 
-			scroll_y_subpx += LSB(cc65_ptr1);
+			scroll_y_subpx = scroll_y_subpx + LSB(cc65_ptr1);
 			do_if_carry({++high_byte(cc65_ptr1);});
-			linear_scroll_y += MSB(cc65_ptr1);
+			linear_scroll_y = linear_scroll_y + MSB(cc65_ptr1);
 		}
 		if (target_scroll_y < linear_scroll_y) {
 			cc65_ptr1 = SHIP_SCROLL_SPEED(framerate);

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -112,7 +112,7 @@ void process_y_scroll() {
 			player1_y = player1_y + cc65_ptr1;
 
 			scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
-			do_if_carry({++high_byte(cc65_ptr1);});
+			do_if_borrow({++high_byte(cc65_ptr1);});
 			linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
 		}
 

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -58,7 +58,7 @@ void process_y_scroll() {
 	if ((!dual || twoplayer) && (gamemode == GAMEMODE_CUBE || gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA || gamemode == GAMEMODE_POGO || nocamlock || nocamlockforced)) {
 			if (exitPortalTimer) exitPortalTimer--;
 			if (player0_y < 0x4000 && 
-				(linear_scroll_y >= min_scroll_y && (scroll_y_subpx || linear_scroll_y != min_scroll_y))
+				(scroll_y >= min_scroll_y && (scroll_y_subpx || scroll_y != min_scroll_y))
 				){
 				// change y scroll (upward)
 				cc65_ptr1 = 0x4000 - player0_y;
@@ -71,11 +71,11 @@ void process_y_scroll() {
 
 				scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
 				do_if_borrow({++high_byte(cc65_ptr1);});
-				linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
+				scroll_y = scroll_y - MSB(cc65_ptr1);
 			}
 			cap_scroll_y_at_top();
 
-			if (linear_scroll_y < 0x2CF && high_byte(player0_y) >= MSB(0xA000)){
+			if (scroll_y < 0x2CF && high_byte(player0_y) >= MSB(0xA000)){
 				// change y scroll (downward)
 				cc65_ptr1 = player0_y - 0xA000;
 				if (exitPortalTimer) {
@@ -87,11 +87,11 @@ void process_y_scroll() {
 
 				scroll_y_subpx = scroll_y_subpx + LSB(cc65_ptr1);
 				do_if_carry({++high_byte(cc65_ptr1);});
-				linear_scroll_y = linear_scroll_y + MSB(cc65_ptr1);
+				scroll_y = scroll_y + MSB(cc65_ptr1);
 			}
 			cap_scroll_y_at_bottom();
 	} else {			//ship stuff
-		if (target_scroll_y > linear_scroll_y) {
+		if (target_scroll_y > scroll_y) {
 			cc65_ptr1 = SHIP_SCROLL_SPEED(framerate);
 			
 			player0_y = player0_y - cc65_ptr1;
@@ -99,9 +99,9 @@ void process_y_scroll() {
 
 			scroll_y_subpx = scroll_y_subpx + LSB(cc65_ptr1);
 			do_if_carry({++high_byte(cc65_ptr1);});
-			linear_scroll_y = linear_scroll_y + MSB(cc65_ptr1);
+			scroll_y = scroll_y + MSB(cc65_ptr1);
 		}
-		if (target_scroll_y < linear_scroll_y) {
+		if (target_scroll_y < scroll_y) {
 			cc65_ptr1 = SHIP_SCROLL_SPEED(framerate);
 			
 			player0_y = player0_y + cc65_ptr1;
@@ -109,7 +109,7 @@ void process_y_scroll() {
 
 			scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
 			do_if_borrow({++high_byte(cc65_ptr1);});
-			linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
+			scroll_y = scroll_y - MSB(cc65_ptr1);
 		}
 
 		cap_scroll_y_at_top();
@@ -122,7 +122,7 @@ void do_the_scroll_thing(){
 	process_y_scroll();
 
     set_scroll_x(scroll_x);
-    set_scroll_y(calculate_ppufmt_scroll_y(linear_scroll_y));
+    set_scroll_y(calculate_ppufmt_scroll_y(scroll_y));
 }
 
 

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -95,10 +95,7 @@ void process_y_scroll() {
 			}
 			cap_scroll_y_at_bottom();
 	} else {			//ship stuff
-		if (low_byte(target_scroll_y) >= 0xf0) {
-			target_scroll_y += 0x10;
-		}
-		if (target_scroll_y > scroll_y) {
+		if (target_scroll_y > linear_scroll_y) {
 			cc65_ptr1 = SHIP_SCROLL_SPEED(framerate);
 			
 			player0_y = player0_y - cc65_ptr1;
@@ -106,21 +103,21 @@ void process_y_scroll() {
 
 			scroll_y_subpx += LSB(cc65_ptr1);
 			do_if_carry({++high_byte(cc65_ptr1);});
-			scroll_y = add_scroll_y(MSB(cc65_ptr1), scroll_y);
+			linear_scroll_y += MSB(cc65_ptr1);
 		}
-		if (target_scroll_y < scroll_y) {
+		if (target_scroll_y < linear_scroll_y) {
 			cc65_ptr1 = SHIP_SCROLL_SPEED(framerate);
 			
 			player0_y = player0_y + cc65_ptr1;
 			player1_y = player1_y + cc65_ptr1;
 
-			scroll_y_subpx -= LSB(cc65_ptr1);
+			scroll_y_subpx = scroll_y_subpx - LSB(cc65_ptr1);
 			do_if_carry({++high_byte(cc65_ptr1);});
-			scroll_y = sub_scroll_y(MSB(cc65_ptr1), scroll_y);
+			linear_scroll_y = linear_scroll_y - MSB(cc65_ptr1);
 		}
 
-		// LAZY LINEAR INSERT!
-		linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+		// LAZY LINEAR INSERT! (but role reversed)
+		scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
 		cap_scroll_y_at_top();
 		cap_scroll_y_at_bottom();
 	}

--- a/SAUCE/functions/scroll.h
+++ b/SAUCE/functions/scroll.h
@@ -58,7 +58,7 @@ void process_y_scroll() {
 	if ((!dual || twoplayer) && (gamemode == GAMEMODE_CUBE || gamemode == GAMEMODE_ROBOT || gamemode == GAMEMODE_NINJA || gamemode == GAMEMODE_POGO || nocamlock || nocamlockforced)) {
 			if (exitPortalTimer) exitPortalTimer--;
 			if (player0_y < 0x4000 && 
-				(scroll_y >= min_scroll_y && (scroll_y_subpx || scroll_y != min_scroll_y))
+				(linear_scroll_y >= min_scroll_y && (scroll_y_subpx || linear_scroll_y != min_scroll_y))
 				){
 				// change y scroll (upward)
 				cc65_ptr1 = 0x4000 - player0_y;

--- a/SAUCE/functions/sprite_loading.h
+++ b/SAUCE/functions/sprite_loading.h
@@ -1174,9 +1174,10 @@ void sprite_collide(){
 		Generic.width = WAVE_WIDTH;
 		Generic.height = WAVE_HEIGHT;
 	}
+	transitional_sixteen_minus_generic_height_halved = (byte(0x10 - Generic.height) >> 1);
 
 	Generic.x = high_byte(currplayer_relx) + 1;
-	Generic.y = high_byte(currplayer_rely) + (byte(0x10 - Generic.height) >> 1);
+	Generic.y = high_byte(currplayer_rely) + transitional_sixteen_minus_generic_height_halved;
 
 	index = 0;
 
@@ -1275,6 +1276,7 @@ void sprite_collide(){
 		Generic.width = WAVE_WIDTH;
 		Generic.height = WAVE_HEIGHT;
 	}
+	transitional_sixteen_minus_generic_height_halved = (byte(0x10 - Generic.height) >> 1);
 }
 
 

--- a/SAUCE/functions/sprite_loading.h
+++ b/SAUCE/functions/sprite_loading.h
@@ -967,7 +967,7 @@ void sprite_collide_lookup() {
 			target_scroll_y = (lohi_arr16_load(activesprites_y, index) - PORTAL_TO_TOP_DIFF);
 			if (twoplayer) { player_gravity[1] = player_gravity[0] ^ 0xFF;  }
 			else { 
-				player_x[1] = player_x[0]; player_y[1] = currplayer_y;
+				player_relx[1] = player_relx[0]; player_rely[1] = currplayer_rely;
 				player_gravity[1] = currplayer_gravity ^ 0xFF;
 				player_vel_y[1] = -currplayer_vel_y; player_mini[1] = player_mini[0];
 			}
@@ -978,7 +978,7 @@ void sprite_collide_lookup() {
 	
 	spcl_sngl_pt:
 		if (!activesprites_activated[index]) {
-			if (!twoplayer) { dual = 0; player_y[0] = currplayer_y; player_gravity[0] = currplayer_gravity; player_vel_y[0] = currplayer_vel_y; }
+			if (!twoplayer) { dual = 0; player_rely[0] = currplayer_rely; player_gravity[0] = currplayer_gravity; player_vel_y[0] = currplayer_vel_y; }
 			else { player_gravity[1] = player_gravity[0]; }
 			activesprites_activated[index] = 1;
 
@@ -994,7 +994,7 @@ void sprite_collide_lookup() {
 			orbed[currplayer] = 1;
 			idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);
 	spcl_tlpt_pt:
-			high_byte(currplayer_y) = teleport_output;
+			high_byte(currplayer_rely) = teleport_output;
 		}
 		return;
 
@@ -1093,12 +1093,12 @@ void sprite_collide_lookup() {
 		if ((cube_data[currplayer] & 2) || (controllingplayer->press & (PAD_A | PAD_UP))) {
 			idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);
 	spcl_sppadup:
-			high_byte(currplayer_y) -= eject_D;
+			high_byte(currplayer_rely) -= eject_D;
 			currplayer_vel_y = 0;
 			currplayer_gravity = GRAVITY_UP;
 			update_currplayer_table_idx();
 			crossPRGBankJump0(spider_up_wait);
-			high_byte(currplayer_y) -= eject_U;
+			high_byte(currplayer_rely) -= eject_U;
 			currplayer_vel_y = 0;	
 			orbed[currplayer] = 1;
 			idx8_inc(activesprites_activated, index);
@@ -1108,12 +1108,12 @@ void sprite_collide_lookup() {
 		if ((cube_data[currplayer] & 2) || (controllingplayer->press & (PAD_A | PAD_UP))) {
 			idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);
 	spcl_sppaddn:
-			high_byte(currplayer_y) -= eject_U + 1;
+			high_byte(currplayer_rely) -= eject_U + 1;
 			currplayer_vel_y = 0;
 			currplayer_gravity = GRAVITY_DOWN;
 			update_currplayer_table_idx();
 			crossPRGBankJump0(spider_down_wait);
-			high_byte(currplayer_y) -= eject_D;
+			high_byte(currplayer_rely) -= eject_D;
 			currplayer_vel_y = 0;
 			orbed[currplayer] = 1;
 			idx8_inc(activesprites_activated, index);
@@ -1175,8 +1175,8 @@ void sprite_collide(){
 		Generic.height = WAVE_HEIGHT;
 	}
 
-	Generic.x = high_byte(currplayer_x) + 1;
-	Generic.y = high_byte(currplayer_y) + (byte(0x10 - Generic.height) >> 1);
+	Generic.x = high_byte(currplayer_relx) + 1;
+	Generic.y = high_byte(currplayer_rely) + (byte(0x10 - Generic.height) >> 1);
 
 	index = 0;
 

--- a/SAUCE/functions/sprite_loading.h
+++ b/SAUCE/functions/sprite_loading.h
@@ -33,7 +33,7 @@ const unsigned char OUTLINES[]={
 		0x0F
 };
 
-#define PORTAL_TO_TOP_DIFF 0x3A
+#define PORTAL_TO_TOP_DIFF 0x5A
 
 #define OUTL    0xFC
 #define COLR    0xFD

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -45,7 +45,7 @@ void x_movement_coll() {
 	
 	Generic.x = high_byte(currplayer_relx);
 	Generic.y = high_byte(currplayer_rely);
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 	// no L/R collision required, since that is accounted for with the death script
 	if (high_byte(currplayer_relx) > 0x10) {
 		bg_coll_floor_spikes(); // check for spikes at the left of the player (fixes standing on spikes)
@@ -68,7 +68,7 @@ void x_movement(){
 //	if (controllingplayer->hold & PAD_LEFT) currplayer_vel_x = 0;
 	
 	if (dashing[currplayer] == 4 || dashing[currplayer] == 5) {	
-		if (currplayer_rely < 0x0600 && linear_scroll_y == min_scroll_y){
+		if (currplayer_rely < 0x0600 && scroll_y == min_scroll_y){
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 		}
 		//return; 
@@ -85,7 +85,7 @@ void x_movement(){
 
 	Generic.x = high_byte(currplayer_relx);
 	Generic.y = high_byte(currplayer_rely);
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 
 	if (!(options & platformer) && !force_platformer) {
 		//if ((controllingplayer->left) && !twoplayer && DEBUG_MODE) currplayer_relx -= currplayer_vel_x;

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -45,7 +45,7 @@ void x_movement_coll() {
 	
 	Generic.x = high_byte(currplayer_relx);
 	Generic.y = high_byte(currplayer_rely);
-	transitional_linear_absolute_currplayer_y = linear_scroll_y + Generic.y;
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 	// no L/R collision required, since that is accounted for with the death script
 	if (high_byte(currplayer_relx) > 0x10) {
 		bg_coll_floor_spikes(); // check for spikes at the left of the player (fixes standing on spikes)

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -43,10 +43,10 @@ void x_movement_coll() {
 		}
 	}
 	
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 	// no L/R collision required, since that is accounted for with the death script
-	if (high_byte(currplayer_x) > 0x10) {
+	if (high_byte(currplayer_relx) > 0x10) {
 		bg_coll_floor_spikes(); // check for spikes at the left of the player (fixes standing on spikes)
 		if (bg_coll_R()) {
 			if (!(options & platformer) && !force_platformer) {idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);}
@@ -60,14 +60,14 @@ void x_movement(){
   mmc3_set_prg_bank_1(GET_BANK(bg_coll_R));
     // handle x
 
-	old_x = currplayer_x;
+	old_x = currplayer_relx;
 	
 	currplayer_vel_x = ind16BE_load_NOC(CUBE_SPEED(framerate), speed);
 	
 //	if (controllingplayer->hold & PAD_LEFT) currplayer_vel_x = 0;
 	
 	if (dashing[currplayer] == 4 || dashing[currplayer] == 5) {	
-		if (currplayer_y < 0x0600 && scroll_y == min_scroll_y){
+		if (currplayer_rely < 0x0600 && scroll_y == min_scroll_y){
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 		}
 		//return; 
@@ -81,45 +81,45 @@ void x_movement(){
 		Generic.height = CUBE_HEIGHT[currplayer_mini];
 	}
 
-	Generic.x = high_byte(currplayer_x); // this is much faster than passing a pointer to player
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx); // this is much faster than passing a pointer to player
+	Generic.y = high_byte(currplayer_rely);
 
 	if (!(options & platformer) && !force_platformer) {
-		//if ((controllingplayer->left) && !twoplayer && DEBUG_MODE) currplayer_x -= currplayer_vel_x;
+		//if ((controllingplayer->left) && !twoplayer && DEBUG_MODE) currplayer_relx -= currplayer_vel_x;
 		//else 
-		currplayer_x += currplayer_vel_x;
+		currplayer_relx += currplayer_vel_x;
 	} else {
 		// leave the col calls first so it executes and checks against spike collision
 		tmp7 = bg_coll_R();
 		tmp8 = bg_coll_L();
 
-		if (!tmp7 && (controllingplayer->right)) currplayer_x += currplayer_vel_x;
-		else if (!tmp8 && controllingplayer->left && currplayer_x > 0x1200) currplayer_x -= currplayer_vel_x;
+		if (!tmp7 && (controllingplayer->right)) currplayer_relx += currplayer_vel_x;
+		else if (!tmp8 && controllingplayer->left && currplayer_relx > 0x1200) currplayer_relx -= currplayer_vel_x;
 		else currplayer_vel_x = 0;
 
 
 		if (tmp7 && (controllingplayer->right)) {
-			tmp7 = high_byte(currplayer_x) + low_word(scroll_x);
-			high_byte(currplayer_x) -= ((tmp7 + 4) & 0x07) - 4 + currplayer_mini; // if mini put it a pixel left-er
+			tmp7 = high_byte(currplayer_relx) + low_word(scroll_x);
+			high_byte(currplayer_relx) -= ((tmp7 + 4) & 0x07) - 4 + currplayer_mini; // if mini put it a pixel left-er
 		}
 		else if (tmp8 && (controllingplayer->left)) {
-			tmp8 = high_byte(currplayer_x) + low_word(scroll_x);
-			high_byte(currplayer_x) -= ((tmp8 + 4) & 0x07) - 4;
+			tmp8 = high_byte(currplayer_relx) + low_word(scroll_x);
+			high_byte(currplayer_relx) -= ((tmp8 + 4) & 0x07) - 4;
 		} 
 	}
 
-	if(currplayer_x > 0xf000) { // too far, don't wrap around
+	if(currplayer_relx > 0xf000) { // too far, don't wrap around
         if(old_x >= 0xf000){
-            currplayer_x = 0xf000; // max right
+            currplayer_relx = 0xf000; // max right
         } else{
-            currplayer_x = 0x0000; // max left
+            currplayer_relx = 0x0000; // max left
         }
 		currplayer_vel_x = 0;
 	} 
 
 
 	if (!wrap_mode) {
-		if (currplayer_y < 0x0600){
+		if (currplayer_rely < 0x0600){
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 		}
 		
@@ -127,11 +127,11 @@ void x_movement(){
 		else if (!(controllingplayer->hold & (PAD_A | PAD_UP))) idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);
 	}
 	else {
-		if (currplayer_y < 0x0600 && !dual && !twoplayer){
-			currplayer_y = 0xF900;
+		if (currplayer_rely < 0x0600 && !dual && !twoplayer){
+			currplayer_rely = 0xF900;
 		}		
-		else if (currplayer_y > 0xF900 && !dual && !twoplayer){
-			currplayer_y = 0x0600;
+		else if (currplayer_rely > 0xF900 && !dual && !twoplayer){
+			currplayer_rely = 0x0600;
 		}		
 		else if (!(controllingplayer->hold & (PAD_A | PAD_UP))) idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);
 	}

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -67,7 +67,7 @@ void x_movement(){
 //	if (controllingplayer->hold & PAD_LEFT) currplayer_vel_x = 0;
 	
 	if (dashing[currplayer] == 4 || dashing[currplayer] == 5) {	
-		if (currplayer_rely < 0x0600 && scroll_y == min_scroll_y){
+		if (currplayer_rely < 0x0600 && linear_scroll_y == min_scroll_y){
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 		}
 		//return; 

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -45,6 +45,7 @@ void x_movement_coll() {
 	
 	Generic.x = high_byte(currplayer_relx);
 	Generic.y = high_byte(currplayer_rely);
+	transitional_linear_absolute_currplayer_y = linear_scroll_y + Generic.y;
 	// no L/R collision required, since that is accounted for with the death script
 	if (high_byte(currplayer_relx) > 0x10) {
 		bg_coll_floor_spikes(); // check for spikes at the left of the player (fixes standing on spikes)

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -81,6 +81,7 @@ void x_movement(){
 		Generic.width = CUBE_WIDTH[currplayer_mini];
 		Generic.height = CUBE_HEIGHT[currplayer_mini];
 	}
+	transitional_sixteen_minus_generic_height_halved = (byte(0x10 - Generic.height) >> 1);
 
 	Generic.x = high_byte(currplayer_relx); // this is much faster than passing a pointer to player
 	Generic.y = high_byte(currplayer_rely);

--- a/SAUCE/functions/x_movement.h
+++ b/SAUCE/functions/x_movement.h
@@ -83,8 +83,9 @@ void x_movement(){
 	}
 	transitional_sixteen_minus_generic_height_halved = (byte(0x10 - Generic.height) >> 1);
 
-	Generic.x = high_byte(currplayer_relx); // this is much faster than passing a pointer to player
+	Generic.x = high_byte(currplayer_relx);
 	Generic.y = high_byte(currplayer_rely);
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 
 	if (!(options & platformer) && !force_platformer) {
 		//if ((controllingplayer->left) && !twoplayer && DEBUG_MODE) currplayer_relx -= currplayer_vel_x;

--- a/SAUCE/gamemodes/gamemode_ball.h
+++ b/SAUCE/gamemodes/gamemode_ball.h
@@ -40,7 +40,6 @@ void ball_movement(){
 	ball_eject();
 
 
-	Generic.y = high_byte(currplayer_rely);
 	Generic.x = high_byte(currplayer_relx);
 
 	// this literally offsets the collision down 1 pixel for the vel reset to happen every frame instead of each other frame
@@ -49,6 +48,7 @@ void ball_movement(){
 	} else {
 		Generic.y = high_byte(currplayer_rely) + 1;
 	}
+	transitional_linear_absolute_currplayer_y = linear_scroll_y + Generic.y;
 
 	if (gamemode == GAMEMODE_BALL) {
 		if (((controllingplayer->hold & (PAD_A | PAD_UP))) && (ball_switched[currplayer] == 0) && currplayer_vel_y == 0 && !orbed[currplayer]){

--- a/SAUCE/gamemodes/gamemode_ball.h
+++ b/SAUCE/gamemodes/gamemode_ball.h
@@ -26,13 +26,13 @@ void ball_movement(){
 		common_gravity_routine();
 	}
 	
-	Generic.x = high_byte(currplayer_x);
+	Generic.x = high_byte(currplayer_relx);
 
 	// this literally offsets the collision down 1 pixel for the vel reset to happen every frame instead of each other frame
 	if (currplayer_gravity) {
-		Generic.y = high_byte(currplayer_y) - 1;
+		Generic.y = high_byte(currplayer_rely) - 1;
 	} else {
-		Generic.y = high_byte(currplayer_y) + 1;
+		Generic.y = high_byte(currplayer_rely) + 1;
 	}
 
 	//if (controllingplayer->press & (PAD_A | PAD_UP)) idx8_store(cube_data, currplayer, cube_data[currplayer] | 2);	
@@ -40,14 +40,14 @@ void ball_movement(){
 	ball_eject();
 
 
-	Generic.y = high_byte(currplayer_y);
-	Generic.x = high_byte(currplayer_x);
+	Generic.y = high_byte(currplayer_rely);
+	Generic.x = high_byte(currplayer_relx);
 
 	// this literally offsets the collision down 1 pixel for the vel reset to happen every frame instead of each other frame
 	if (currplayer_gravity) {
-		Generic.y = high_byte(currplayer_y) - 1;
+		Generic.y = high_byte(currplayer_rely) - 1;
 	} else {
-		Generic.y = high_byte(currplayer_y) + 1;
+		Generic.y = high_byte(currplayer_rely) + 1;
 	}
 
 	if (gamemode == GAMEMODE_BALL) {
@@ -89,7 +89,7 @@ void ball_eject() {
 	
 		//if(high_byte(currplayer_vel_y) & 0x80){
 			if(bg_coll_U()){ // check collision above
-				high_byte(currplayer_y) = high_byte(currplayer_y) - eject_U;
+				high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_U;
 				if (gamemode != GAMEMODE_POGO) currplayer_vel_y = 0;
 				else {
 					if (!currplayer_gravity) currplayer_vel_y = 0;
@@ -107,7 +107,7 @@ void ball_eject() {
 		//}
 		//else{
 			if(bg_coll_D()){ // check collision below
-			    high_byte(currplayer_y) = high_byte(currplayer_y) - eject_D;
+			    high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_D;
 				if (gamemode != GAMEMODE_POGO) currplayer_vel_y = 0;
 				else {
 					if (currplayer_gravity) currplayer_vel_y = 0;

--- a/SAUCE/gamemodes/gamemode_ball.h
+++ b/SAUCE/gamemodes/gamemode_ball.h
@@ -48,7 +48,7 @@ void ball_movement(){
 	} else {
 		Generic.y = high_byte(currplayer_rely) + 1;
 	}
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 
 	if (gamemode == GAMEMODE_BALL) {
 		if (((controllingplayer->hold & (PAD_A | PAD_UP))) && (ball_switched[currplayer] == 0) && currplayer_vel_y == 0 && !orbed[currplayer]){

--- a/SAUCE/gamemodes/gamemode_ball.h
+++ b/SAUCE/gamemodes/gamemode_ball.h
@@ -48,7 +48,7 @@ void ball_movement(){
 	} else {
 		Generic.y = high_byte(currplayer_rely) + 1;
 	}
-	transitional_linear_absolute_currplayer_y = linear_scroll_y + Generic.y;
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 
 	if (gamemode == GAMEMODE_BALL) {
 		if (((controllingplayer->hold & (PAD_A | PAD_UP))) && (ball_switched[currplayer] == 0) && currplayer_vel_y == 0 && !orbed[currplayer]){

--- a/SAUCE/gamemodes/gamemode_cube.h
+++ b/SAUCE/gamemodes/gamemode_cube.h
@@ -22,16 +22,16 @@ void cube_movement(){
 
 	common_gravity_routine();
 
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 	
 	
 	cube_eject();
 	
 
 	// check collision down a little lower than CUBE
-	Generic.x = high_byte(currplayer_x); // the rest should be the same
-	Generic.y = high_byte(currplayer_y); // the rest should be the same
+	Generic.x = high_byte(currplayer_relx); // the rest should be the same
+	Generic.y = high_byte(currplayer_rely); // the rest should be the same
 
 	update_currplayer_table_idx();
 
@@ -188,7 +188,7 @@ void common_gravity_routine() {
 		currplayer_vel_y = currplayer_vel_x;
 	} else if (tmp1 == 4) {
 		currplayer_vel_y = currplayer_vel_x*2;
-		currplayer_y -= currplayer_vel_y;
+		currplayer_rely -= currplayer_vel_y;
 		return;
 	} else if (tmp1 == 5) {
 		currplayer_vel_y = currplayer_vel_x*2;
@@ -196,7 +196,7 @@ void common_gravity_routine() {
 		currplayer_vel_y = currplayer_gravity ? -1 : 1;
 		return;
 	}
-	currplayer_y += currplayer_vel_y;
+	currplayer_rely += currplayer_vel_y;
 }
 
 
@@ -204,8 +204,8 @@ void cube_eject() {
 	//if (!currplayer_was_on_slope_counter || currplayer_slope_type & SLOPE_UPSIDEDOWN) {
 		if(!currplayer_gravity || (currplayer_gravity && (hblocked[currplayer] | fblocked[currplayer]))){
 			if(bg_coll_D()){ // check collision below
-				high_byte(currplayer_y) -= eject_D;
-				low_byte(currplayer_y) = 0;
+				high_byte(currplayer_rely) -= eject_D;
+				low_byte(currplayer_rely) = 0;
 				if (!hblocked[currplayer]) {
 					currplayer_vel_y = 0;
 				} else {
@@ -222,8 +222,8 @@ void cube_eject() {
 	//if (!currplayer_was_on_slope_counter || !(currplayer_slope_type & SLOPE_UPSIDEDOWN)) {
 		if (currplayer_gravity || (!currplayer_gravity && (hblocked[currplayer] | fblocked[currplayer]))) {
 			if(bg_coll_U()){ // check collision above
-				high_byte(currplayer_y) -= eject_U;
-				low_byte(currplayer_y) = 0;
+				high_byte(currplayer_rely) -= eject_U;
+				low_byte(currplayer_rely) = 0;
 				if (!hblocked[currplayer]) {
 					currplayer_vel_y = 0;
 				} else {

--- a/SAUCE/gamemodes/gamemode_ship.h
+++ b/SAUCE/gamemodes/gamemode_ship.h
@@ -47,8 +47,8 @@ void ship_movement(){
 		if(currplayer_vel_y > 0x0369) currplayer_vel_y = 0x0369;
 	}
 
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 
 	
 	ufo_ship_eject();
@@ -58,13 +58,13 @@ void ship_movement(){
 void ufo_ship_eject() {
 	//if (!currplayer_was_on_slope_counter || currplayer_slope_type & SLOPE_UPSIDEDOWN) {
 		if(bg_coll_U()){ // check collision above
-			high_byte(currplayer_y) = high_byte(currplayer_y) - eject_U - 1;
+			high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_U - 1;
 			currplayer_vel_y = 0;
 		}
 	//}
 	//if (!currplayer_was_on_slope_counter || !(currplayer_slope_type & SLOPE_UPSIDEDOWN)) {
 		if(bg_coll_D()){ // check collision below
-			high_byte(currplayer_y) = high_byte(currplayer_y) - eject_D;
+			high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_D;
 			currplayer_vel_y = 0;
 		}
 	//}

--- a/SAUCE/gamemodes/gamemode_spider.h
+++ b/SAUCE/gamemodes/gamemode_spider.h
@@ -11,13 +11,13 @@ void spider_movement(){
 
 	common_gravity_routine();
 
-	Generic.x = high_byte(currplayer_x);
+	Generic.x = high_byte(currplayer_relx);
 	
 	// this literally offsets the collision down 1 pixel for the vel reset to happen every frame instead of each other frame
 	if (currplayer_gravity) {
-		Generic.y = high_byte(currplayer_y) - 2;
+		Generic.y = high_byte(currplayer_rely) - 2;
 	} else {
-		Generic.y = high_byte(currplayer_y) + 1;
+		Generic.y = high_byte(currplayer_rely) + 1;
 	}
 	
 	spider_eject();
@@ -31,7 +31,7 @@ void spider_movement(){
 			currplayer_gravity = GRAVITY_UP;
 			update_currplayer_table_idx();
 			spider_up_wait();
-			high_byte(currplayer_y) -= eject_U;
+			high_byte(currplayer_rely) -= eject_U;
 			currplayer_vel_y = 0;
 			black_orbed[currplayer] = 0;
 		}
@@ -46,7 +46,7 @@ void spider_movement(){
 			currplayer_gravity = GRAVITY_DOWN;
 			update_currplayer_table_idx();
 			spider_down_wait();
-			high_byte(currplayer_y) -= eject_D;
+			high_byte(currplayer_rely) -= eject_D;
 			currplayer_vel_y = 0;
 			black_orbed[currplayer] = 0;
 		}
@@ -57,13 +57,13 @@ void spider_movement(){
 	// this literally offsets the collision down 1 pixel for the vel reset to happen every frame instead of each other frame
 
 /*	if (currplayer_gravity) {
-		Generic.y = high_byte(currplayer_y) - 2;
+		Generic.y = high_byte(currplayer_rely) - 2;
 	} else {
-		Generic.y = high_byte(currplayer_y) + 1;
+		Generic.y = high_byte(currplayer_rely) + 1;
 	}		*/   									//this seemed to be unused??
 
 	// check collision down a little lower than CUBE
-	Generic.y = high_byte(currplayer_y); // the rest should be the same
+	Generic.y = high_byte(currplayer_rely); // the rest should be the same
 
 
 }	
@@ -73,14 +73,14 @@ void spider_movement(){
 void spider_eject() {
 	if(!currplayer_gravity){
 		if(bg_coll_D()){ // check collision below
-			high_byte(currplayer_y) -= eject_D;
+			high_byte(currplayer_rely) -= eject_D;
 			currplayer_vel_y = 0;
 
 
 		}
 	} else {
 		if(bg_coll_U()){ // check collision above
-			high_byte(currplayer_y) -= eject_U + 1;
+			high_byte(currplayer_rely) -= eject_U + 1;
 			currplayer_vel_y = 0;
 
 		} 
@@ -92,13 +92,13 @@ void spider_up_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
 	do {
-		high_byte(currplayer_y) -= 0x08;
+		high_byte(currplayer_rely) -= 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_y) <= 0x07){ // && scroll_y <= min_scroll_y
+		if (high_byte(currplayer_rely) <= 0x07){ // && scroll_y <= min_scroll_y
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}
-		Generic.y = high_byte(currplayer_y); // the rest should be the same
+		Generic.y = high_byte(currplayer_rely); // the rest should be the same
 	} while (!bg_coll_U_spider());
 }			
 
@@ -106,13 +106,13 @@ void spider_down_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
 	do {
-		high_byte(currplayer_y) += 0x08;
+		high_byte(currplayer_rely) += 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_y) >= 0xF8) { //&& scroll_y <= min_scroll_y)
+		if (high_byte(currplayer_rely) >= 0xF8) { //&& scroll_y <= min_scroll_y)
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}
-		Generic.y = high_byte(currplayer_y); // the rest should be the same
+		Generic.y = high_byte(currplayer_rely); // the rest should be the same
 	} while (!bg_coll_D_spider());
 }				
 #undef LEFT_POS

--- a/SAUCE/gamemodes/gamemode_spider.h
+++ b/SAUCE/gamemodes/gamemode_spider.h
@@ -91,8 +91,10 @@ void spider_eject() {
 void spider_up_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 	do {
 		high_byte(currplayer_rely) -= 0x08;
+		transitional_linear_absolute_currplayer_y -= 0x08;
 		crossPRGBankJump0(process_y_scroll);
 		if (high_byte(currplayer_rely) <= 0x07){ // && linear_scroll_y <= min_scroll_y
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
@@ -105,8 +107,10 @@ void spider_up_wait() {
 void spider_down_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
+	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
 	do {
 		high_byte(currplayer_rely) += 0x08;
+		transitional_linear_absolute_currplayer_y += 0x08;
 		crossPRGBankJump0(process_y_scroll);
 		if (high_byte(currplayer_rely) >= 0xF8) { //&& linear_scroll_y <= min_scroll_y)
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high

--- a/SAUCE/gamemodes/gamemode_spider.h
+++ b/SAUCE/gamemodes/gamemode_spider.h
@@ -91,12 +91,12 @@ void spider_eject() {
 void spider_up_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 	do {
 		high_byte(currplayer_rely) -= 0x08;
 		transitional_linear_absolute_currplayer_y -= 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_rely) <= 0x07){ // && linear_scroll_y <= min_scroll_y
+		if (high_byte(currplayer_rely) <= 0x07){ // && scroll_y <= min_scroll_y
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}
@@ -107,12 +107,12 @@ void spider_up_wait() {
 void spider_down_wait() {
 	LEFT_POS = Generic.x + low_word(scroll_x) + 3;
 	RIGHT_POS = Generic.x + low_word(scroll_x) + Generic.width - 3;
-	transitional_linear_absolute_currplayer_y = Generic.y + linear_scroll_y;
+	transitional_linear_absolute_currplayer_y = Generic.y + scroll_y;
 	do {
 		high_byte(currplayer_rely) += 0x08;
 		transitional_linear_absolute_currplayer_y += 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_rely) >= 0xF8) { //&& linear_scroll_y <= min_scroll_y)
+		if (high_byte(currplayer_rely) >= 0xF8) { //&& scroll_y <= min_scroll_y)
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}

--- a/SAUCE/gamemodes/gamemode_spider.h
+++ b/SAUCE/gamemodes/gamemode_spider.h
@@ -94,7 +94,7 @@ void spider_up_wait() {
 	do {
 		high_byte(currplayer_rely) -= 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_rely) <= 0x07){ // && scroll_y <= min_scroll_y
+		if (high_byte(currplayer_rely) <= 0x07){ // && linear_scroll_y <= min_scroll_y
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}
@@ -108,7 +108,7 @@ void spider_down_wait() {
 	do {
 		high_byte(currplayer_rely) += 0x08;
 		crossPRGBankJump0(process_y_scroll);
-		if (high_byte(currplayer_rely) >= 0xF8) { //&& scroll_y <= min_scroll_y)
+		if (high_byte(currplayer_rely) >= 0xF8) { //&& linear_scroll_y <= min_scroll_y)
 			idx8_store(cube_data, currplayer, cube_data[currplayer] | 0x01);	//DIE if player goes too high
 			break;
 		}

--- a/SAUCE/gamemodes/gamemode_ufo.h
+++ b/SAUCE/gamemodes/gamemode_ufo.h
@@ -11,17 +11,17 @@ void ufo_movement(){
 		
 
 
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 
 	ufo_ship_eject();
 
 	
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 
 	// check collision down a little lower than UFO
-//	Generic.y = high_byte(currplayer_y); // the rest should be the same
+//	Generic.y = high_byte(currplayer_rely); // the rest should be the same
 
 
 	if((controllingplayer->press & (PAD_A | PAD_UP)) && !ufo_orbed[currplayer]) {

--- a/SAUCE/gamemodes/gamemode_wave.h
+++ b/SAUCE/gamemodes/gamemode_wave.h
@@ -23,22 +23,22 @@ void wave_movement(){
 			}
 
 			if (!currplayer_slope_frames && !currplayer_was_on_slope_counter) {
-				currplayer_y += currplayer_vel_y;
+				currplayer_rely += currplayer_vel_y;
 			} else {
 				currplayer_vel_y = 0;
 			}
 			break;
 		case 1: currplayer_vel_y = 1; break;
-		case 2: currplayer_vel_y = -currplayer_vel_x; currplayer_y += currplayer_vel_y; break;
-		case 3: currplayer_vel_y = currplayer_vel_x; currplayer_y += currplayer_vel_y; break;
-		case 4: currplayer_vel_y = currplayer_vel_x; currplayer_y -= currplayer_vel_y; break;
-		case 5: currplayer_vel_y = currplayer_vel_x; currplayer_y += currplayer_vel_y; break;
+		case 2: currplayer_vel_y = -currplayer_vel_x; currplayer_rely += currplayer_vel_y; break;
+		case 3: currplayer_vel_y = currplayer_vel_x; currplayer_rely += currplayer_vel_y; break;
+		case 4: currplayer_vel_y = currplayer_vel_x; currplayer_rely -= currplayer_vel_y; break;
+		case 5: currplayer_vel_y = currplayer_vel_x; currplayer_rely += currplayer_vel_y; break;
 
 	};
-	Generic.x = high_byte(currplayer_x) + 4;
+	Generic.x = high_byte(currplayer_relx) + 4;
 	
 	// this literally offsets the collision down 2 pixel for the vel reset to happen every frame instead of each other frame
-	Generic.y = high_byte(currplayer_y) + (currplayer_mini ? 0 : 4);
+	Generic.y = high_byte(currplayer_rely) + (currplayer_mini ? 0 : 4);
 	
 	
 
@@ -46,8 +46,8 @@ void wave_movement(){
 	
 
 
-	Generic.x = high_byte(currplayer_x);
-	Generic.y = high_byte(currplayer_y);
+	Generic.x = high_byte(currplayer_relx);
+	Generic.y = high_byte(currplayer_rely);
 
 //	if (currplayer_vel_y != 0 && !slope_type){
 //		if(controllingplayer->press & (PAD_A | PAD_UP)) {
@@ -63,7 +63,7 @@ void wave_eject() {
 	if(high_byte(currplayer_vel_y) & 0x80){
 		if (bg_coll_U()) {
 			if(dblocked[currplayer]){ // check collision above
-				high_byte(currplayer_y) = high_byte(currplayer_y) - eject_U;
+				high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_U;
 				currplayer_vel_y = 0;
 				idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);			
 			} else {
@@ -74,7 +74,7 @@ void wave_eject() {
 	else{
 		if(bg_coll_D()){ // check collision below
 			if (dblocked[currplayer]) {
-				high_byte(currplayer_y) = high_byte(currplayer_y) - eject_D;
+				high_byte(currplayer_rely) = high_byte(currplayer_rely) - eject_D;
 				currplayer_vel_y = 0;
 				idx8_store(cube_data, currplayer, cube_data[currplayer] & 1);		    
 			} else {

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -364,10 +364,9 @@ void everything_else() {
 				
 				if (mouse.left) {
 					kandodebugmode = 2;
-					//high_byte(currplayer_relx) = mouse.x + high_byte(scroll_x);
 					target_x_scroll_stop = 0xE000;
 					curr_x_scroll_stop = 0xE000;
-					high_byte(currplayer_rely) = (mouse.y + high_byte(scroll_y)) - 10;
+					high_byte(currplayer_rely) = mouse.y - 10;
 					high_byte(currplayer_relx) = mouse.x - 10 < 0 ? mouse.x : mouse.x - 10;
 					if (high_byte(currplayer_relx) > 226) high_byte(currplayer_relx) = 226;
 					

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -178,12 +178,7 @@ void state_game(){
 
 		if (((forced_trails == 2) || trails == 2 || !(kandoframecnt & 0x1))) {
 			if (!(kandoframecnt & 1)) {
-				if (old_trail_scroll_y >= scroll_y) {
-					tmp6 = calculate_linear_scroll_y(sub_scroll_y_ext(scroll_y, old_trail_scroll_y));
-				} else {
-					tmp6 = calculate_linear_scroll_y(sub_scroll_y_ext(old_trail_scroll_y, scroll_y));
-					tmp6 ^= 0xFFFF; tmp6++;
-				}
+				tmp6 = old_trail_scroll_y - linear_scroll_y;
 				tmp3 = 7;
 				do {
 					tmp5 = player_old_rely[tmp3] + tmp6;
@@ -192,7 +187,7 @@ void state_game(){
 					--tmp3;
 				} while ((int8_t)tmp3 >= 0);
 				player_old_rely[0] = high_byte(player_rely[0]);
-				old_trail_scroll_y = scroll_y;
+				old_trail_scroll_y = linear_scroll_y;
 			}
 		}
 		if (discomode && !(kandoframecnt & discorefreshrate)) {

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -119,7 +119,7 @@ void state_game(){
 	pal_col(0x0A,0x0F);   //palette 2 set to 0x0F for mountains
 	pal_col(0x0B,color1);   //palette 2 set to player color
 
-	memfill(player_old_posy, 0, sizeof(player_old_posy));
+	memfill(player_old_rely, 0, sizeof(player_old_rely));
 	
 	switch (discomode) {
 		default: 
@@ -184,12 +184,12 @@ void state_game(){
 				}
 				tmp3 = 7;
 				do {
-					tmp5 = player_old_posy[tmp3] + tmp6;
+					tmp5 = player_old_rely[tmp3] + tmp6;
 					if (high_byte(tmp5) != 0) low_byte(tmp5) = 0;
-					(&player_old_posy[1])[tmp3] = tmp5;
+					(&player_old_rely[1])[tmp3] = tmp5;
 					--tmp3;
 				} while ((int8_t)tmp3 >= 0);
-				player_old_posy[0] = high_byte(player_rely[0]);
+				player_old_rely[0] = high_byte(player_rely[0]);
 				old_trail_scroll_y = scroll_y;
 			}
 		}

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -104,6 +104,8 @@ void state_game(){
 
 	scroll_y = spawn_scroll_y_pos;
 	seam_scroll_y = (spawn_scroll_y_pos - 0x78); // [temp]	
+	// LAZY LINEAR INSERT!
+	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
 	set_scroll_y(scroll_y);
 
 	player_rely[0] = spawn_y_pos;

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -106,9 +106,9 @@ void state_game(){
 	seam_scroll_y = (spawn_scroll_y_pos - 0x78); // [temp]	
 	set_scroll_y(scroll_y);
 
-	player_y[0] = spawn_y_pos;
-	player_y[1] = spawn_y_pos;
-	currplayer_y = spawn_y_pos;	
+	player_rely[0] = spawn_y_pos;
+	player_rely[1] = spawn_y_pos;
+	currplayer_rely = spawn_y_pos;
 	
 	update_currplayer_table_idx();
 
@@ -189,7 +189,7 @@ void state_game(){
 					(&player_old_posy[1])[tmp3] = tmp5;
 					--tmp3;
 				} while ((int8_t)tmp3 >= 0);
-				player_old_posy[0] = high_byte(player_y[0]);
+				player_old_posy[0] = high_byte(player_rely[0]);
 				old_trail_scroll_y = scroll_y;
 			}
 		}
@@ -247,7 +247,7 @@ void state_game(){
 
 		if ((DEBUG_MODE == 1) || (DEBUG_MODE == 2)) gray_line();
 		if (!DEBUG_MODE && kandodebugmode != 2) {
-		if (high_byte(player_x[0]) > 0x20) {
+		if (high_byte(player_relx[0]) > 0x20) {
 			if (cube_data[0] & 1 || cube_data[1] & 1) {
 				death_animation();
 				mmc3_set_prg_bank_1(GET_BANK(reset_level));
@@ -381,12 +381,12 @@ void everything_else() {
 				
 				if (mouse.left) {
 					kandodebugmode = 2;
-					//high_byte(currplayer_x) = mouse.x + high_byte(scroll_x);
+					//high_byte(currplayer_relx) = mouse.x + high_byte(scroll_x);
 					target_x_scroll_stop = 0xE000;
 					curr_x_scroll_stop = 0xE000;
-					high_byte(currplayer_y) = (mouse.y + high_byte(scroll_y)) - 10;
-					high_byte(currplayer_x) = mouse.x - 10 < 0 ? mouse.x : mouse.x - 10;
-					if (high_byte(currplayer_x) > 226) high_byte(currplayer_x) = 226;
+					high_byte(currplayer_rely) = (mouse.y + high_byte(scroll_y)) - 10;
+					high_byte(currplayer_relx) = mouse.x - 10 < 0 ? mouse.x : mouse.x - 10;
+					if (high_byte(currplayer_relx) > 226) high_byte(currplayer_relx) = 226;
 					
 				}
 				else {
@@ -591,8 +591,8 @@ void everything_else() {
 
 		mmc3_set_prg_bank_1(GET_BANK(sprite_collide));
 		{	// always store it back for practice mode
-			player_x[0] = currplayer_x;
-			player_y[0] = currplayer_y;
+			player_relx[0] = currplayer_relx;
+			player_rely[0] = currplayer_rely;
 			player_vel_x[0] = currplayer_vel_x;
 			player_vel_y[0] = currplayer_vel_y;
 			player_gravity[0] = currplayer_gravity;
@@ -614,8 +614,8 @@ void everything_else() {
 
 
 			{	
-				currplayer_x = player_x[1];
-				currplayer_y = player_y[1];
+				currplayer_relx = player_relx[1];
+				currplayer_rely = player_rely[1];
 				currplayer_vel_x = player_vel_x[1];
 				currplayer_vel_y = player_vel_y[1];
 				currplayer_gravity = player_gravity[1];
@@ -644,8 +644,8 @@ void everything_else() {
 			#endif
 			crossPRGBankJump0(movement);
 
-			if (dual && ((options & platformer) || force_platformer) && !twoplayer) { currplayer_x = player_x[0]; currplayer_vel_x = player_vel_x[0]; }
-			else if (dual && !(options & platformer) && !force_platformer) { currplayer_x = player_x[0]; currplayer_vel_x = player_vel_x[0]; }
+			if (dual && ((options & platformer) || force_platformer) && !twoplayer) { currplayer_relx = player_relx[0]; currplayer_vel_x = player_vel_x[0]; }
+			else if (dual && !(options & platformer) && !force_platformer) { currplayer_relx = player_relx[0]; currplayer_vel_x = player_vel_x[0]; }
 
 			processXMovement = 0;
 			runthecolls();
@@ -657,8 +657,8 @@ void everything_else() {
 			controllingplayer = &joypad1;		//give back controls
 
 			{
-				player_x[1] = currplayer_x;
-				player_y[1] = currplayer_y;
+				player_relx[1] = currplayer_relx;
+				player_rely[1] = currplayer_rely;
 				player_vel_x[1] = currplayer_vel_x;
 				player_vel_y[1] = currplayer_vel_y;
 				player_gravity[1] = currplayer_gravity;
@@ -668,8 +668,8 @@ void everything_else() {
 				slope_type[1] = currplayer_slope_type;
 				last_slope_type[1] = currplayer_last_slope_type;
 
-				currplayer_x = player_x[0];
-				currplayer_y = player_y[0];
+				currplayer_relx = player_relx[0];
+				currplayer_rely = player_rely[0];
 				currplayer_vel_x = player_vel_x[0];
 				currplayer_vel_y = player_vel_y[0];
 				currplayer_gravity = player_gravity[0];

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -102,10 +102,10 @@ void state_game(){
 	mmc3_set_prg_bank_1(GET_BANK(reset_level));
 	reset_level();
 
-	scroll_y = spawn_scroll_y_pos;
-	seam_scroll_y = (spawn_scroll_y_pos - 0x78); // [temp]	
-	// LAZY LINEAR INSERT!
-	linear_scroll_y = calculate_linear_scroll_y(scroll_y);
+	linear_scroll_y = spawn_scroll_y_pos;
+	// LAZY LINEAR INSERT! (but role reversed)
+	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
+	seam_scroll_y = (scroll_y - 0x78); // [temp]
 	set_scroll_y(scroll_y);
 
 	player_rely[0] = spawn_y_pos;

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -164,7 +164,7 @@ void state_game(){
 
 		if (((forced_trails == 2) || trails == 2 || !(kandoframecnt & 0x1))) {
 			if (!(kandoframecnt & 1)) {
-				tmp6 = old_trail_scroll_y - linear_scroll_y;
+				tmp6 = old_trail_scroll_y - scroll_y;
 				tmp3 = 7;
 				do {
 					tmp5 = player_old_rely[tmp3] + tmp6;
@@ -173,7 +173,7 @@ void state_game(){
 					--tmp3;
 				} while ((int8_t)tmp3 >= 0);
 				player_old_rely[0] = high_byte(player_rely[0]);
-				old_trail_scroll_y = linear_scroll_y;
+				old_trail_scroll_y = scroll_y;
 			}
 		}
 		if (discomode && !(kandoframecnt & discorefreshrate)) {

--- a/SAUCE/gamestates/state_game.h
+++ b/SAUCE/gamestates/state_game.h
@@ -102,20 +102,6 @@ void state_game(){
 	mmc3_set_prg_bank_1(GET_BANK(reset_level));
 	reset_level();
 
-	linear_scroll_y = spawn_scroll_y_pos;
-	// LAZY LINEAR INSERT! (but role reversed)
-	scroll_y = calculate_ppufmt_scroll_y(linear_scroll_y);
-	seam_scroll_y = (scroll_y - 0x78); // [temp]
-	set_scroll_y(scroll_y);
-
-	player_rely[0] = spawn_y_pos;
-	player_rely[1] = spawn_y_pos;
-	currplayer_rely = spawn_y_pos;
-	
-	update_currplayer_table_idx();
-
-
-	
 	iconbank = (icon<<1) + 40;
 
 	pal_col(0x0A,0x0F);   //palette 2 set to 0x0F for mountains

--- a/SAUCE/menustates/titlescreen.c
+++ b/SAUCE/menustates/titlescreen.c
@@ -103,8 +103,8 @@ void check_if_music_stopped2() {
 #endif
 
 void hi_byte_stuff() {
-	high_byte(player_x[0]) = currplayer_x_small;
-	high_byte(player_y[0]) = currplayer_y_small;
+	high_byte(player_relx[0]) = currplayer_x_small;
+	high_byte(player_rely[0]) = currplayer_y_small;
 }	
 
 void state_menu() {


### PR DESCRIPTION
BREAKING CHANGES:
`target_scroll_y` is now linear in a way that wasn't before. keeping compatibility is impossible. changing the hard coded offset may be required for better camera experience.
the level metadata variables `scrollYPositionHi` and `Low` have been replaced with `scrollYPosition`. also this variable now uses the linear value as opposed to the old ppufmt scroll y. fix yo editors folks

You have 36 hours to review this / test the game and tell me any things to fix (after all there's more changes to come). the game has been tested on Death Moon and it works at least
after that i rebase and merge into main, and then i continue working on the coordinates